### PR TITLE
[MODEMAIL-13] Module descriptor - remove _tenant interface

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -25,25 +25,6 @@
           ]
         }
       ]
-    },
-    {
-      "id": "_tenant",
-      "version": "1.0",
-      "interfaceType": "system",
-      "handlers": [
-        {
-          "methods": [
-            "POST"
-          ],
-          "pathPattern": "/_/tenant"
-        },
-        {
-          "methods": [
-            "DELETE"
-          ],
-          "pathPattern": "/_/tenant"
-        }
-      ]
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
Resolves: MODEMAIL-13

 The module provides tenant API which is not needed as the module does not have a database schema. Tenant API fails because of schema absence. 
## Links
https://issues.folio.org/browse/MODEMAIL-13