### PR TITLE
MODEMAIL-14 The 'Vertx.MailClient' configuration for sending email should not cache the first configuration for the SMTP server

### DIFF
--- a/src/main/java/org/folio/services/impl/MailServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/MailServiceImpl.java
@@ -54,7 +54,7 @@ public class MailServiceImpl implements MailService {
       MailConfig mailConfig = getMailConfig(configurations);
       MailMessage mailMessage = getMailMessage(emailEntity, configurations);
       MailClient
-        .createShared(vertx, mailConfig)
+        .createNonShared(vertx, mailConfig)
         .sendMail(mailMessage, mailHandler -> {
           if (mailHandler.failed()) {
             logger.error(String.format(ERROR_SENDING_EMAIL, mailHandler.cause().getMessage()));

--- a/src/test/java/org/folio/rest/impl/EmailAPITest.java
+++ b/src/test/java/org/folio/rest/impl/EmailAPITest.java
@@ -83,7 +83,7 @@ public class EmailAPITest {
   @Test
   public void checkIncorrectConfigurationFromConfigModule() {
     int mockServerPort = userMockServer.port();
-    initModConfigStub(mockServerPort, getInvalidConfigurations());
+    initModConfigStub(mockServerPort, getIncorrectConfigurations());
 
     String okapiUrl = String.format(OKAPI_URL_TEMPLATE, mockServerPort);
     String okapiEmailEntity = getEmailEntity("user@user.com", "admin@admin.com", null);


### PR DESCRIPTION
## Purpose
Change the SMTP configuration caching impl

## Link
[MODEMAIL-14](https://issues.folio.org/browse/MODEMAIL-14)