### PR TITLE
FOLIO-2003 initial module metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,9 @@ curl -w '\n' -X POST -D -   \
 
 See project [MODEMAIL](https://issues.folio.org/browse/MODEMAIL)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker/).
+
+### ModuleDescriptor
+
+See the built `target/ModuleDescriptor.json` for the interfaces that this module
+requires and provides, the permissions, and the additional module metadata.
+

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -34,6 +34,10 @@
       "description": "send email notifications"
     }
   ],
+  "metadata": {
+    "containerMemory": "256",
+    "databaseConnection": "false"
+  },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {


### PR DESCRIPTION
Declare additional module metadata in ModuleDescriptor: containerMemory, databaseConnection

[FOLIO-2003](https://issues.folio.org/browse/FOLIO-2003)