### PR TITLE
MODEMAIL-21 Implement an endpoint for getting all emails for metrics

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,14 +3,14 @@
   "name": "email",
   "requires": [
     {
-    "id": "configuration",
-    "version": "2.0"
+      "id": "configuration",
+      "version": "2.0"
     }
   ],
   "provides": [
     {
       "id": "email",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": [
@@ -23,6 +23,64 @@
           "modulePermissions": [
             "configuration.entries.collection.get"
           ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/email",
+          "permissionsRequired": [
+            "email.message.collection.get"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "delayedTasks",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "pathPattern": "/delayedTask/expiredMessages",
+          "modulePermissions": [
+            "email.message.delete"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "_tenant",
+      "version": "1.0",
+      "interfaceType": "system",
+      "handlers": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/_/tenant"
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "pathPattern": "/_/tenant"
+        }
+      ]
+    },
+    {
+      "id": "_timer",
+      "version": "1.0",
+      "interfaceType": "system",
+      "handlers": [
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "pathPattern": "/delayedTask/expiredMessages",
+          "unit": "minute",
+          "delay": "30"
         }
       ]
     }
@@ -32,11 +90,32 @@
       "permissionName": "email.message.post",
       "displayName": "message - send email notifications",
       "description": "send email notifications"
+    },
+    {
+      "permissionName": "email.message.collection.get",
+      "displayName": "get email messages",
+      "description": "get all email messages by query"
+    },
+    {
+      "permissionName": "email.message.delete",
+      "displayName": "delete email message",
+      "description": "delete email messages by expiration date or status"
+    },
+    {
+      "permissionName": "email.message.all",
+      "displayName": "email entries - all permissions",
+      "description": "Entire set of permissions needed to use the email module",
+      "subPermissions": [
+        "email.message.post",
+        "email.message.collection.get",
+        "email.message.delete"
+      ],
+      "visible": false
     }
   ],
   "metadata": {
     "containerMemory": "256",
-    "databaseConnection": "false"
+    "databaseConnection": "true"
   },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -10,7 +10,7 @@
   "provides": [
     {
       "id": "email",
-      "version": "2.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [

--- a/ramls/delayedTasks.raml
+++ b/ramls/delayedTasks.raml
@@ -18,10 +18,6 @@ traits:
   pageable:  !include raml-util/traits/pageable.raml
   searchable: !include raml-util/traits/searchable.raml
 
-resourceTypes:
-  collection: !include raml-util/rtypes/collection.raml
-  collection-item-get: !include raml-util/rtypes/item-collection-get.raml
-
 /delayedTask:
   /expiredMessages:
     delete:
@@ -45,11 +41,6 @@ resourceTypes:
           body:
             text/plain:
               example: "No Content"
-        400:
-          description: "Bad Request"
-          body:
-            text/plain:
-              example: "Error message"
         500:
           description: "Internal server error"
           body:

--- a/ramls/delayedTasks.raml
+++ b/ramls/delayedTasks.raml
@@ -1,0 +1,57 @@
+#%RAML 1.0
+
+title: Trigger API
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost
+
+documentation:
+  - title: mod-email API
+    content: The module should provide the ability to delete emails by status and date through the REST API
+
+types:
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  validate: !include raml-util/traits/validation.raml
+  language: !include raml-util/traits/language.raml
+  pageable:  !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item-get: !include raml-util/rtypes/item-collection-get.raml
+
+/delayedTask:
+  /expiredMessages:
+    delete:
+      queryParameters:
+        expirationDate:
+          displayName: date
+          description: "Expiration Date"
+          example: "2019-01-31"
+          type: string
+          required: false
+        emailStatus:
+          displayName: status
+          description: "Email status"
+          example: "DELIVERED"
+          type: string
+          required: false
+      description: "delete expired email messages"
+      responses:
+        204:
+          description: "success"
+          body:
+            text/plain:
+              example: "No Content"
+        400:
+          description: "Bad Request"
+          body:
+            text/plain:
+              example: "Error message"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"

--- a/ramls/email.raml
+++ b/ramls/email.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Email API
-version: v0.1
+version: v2.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -12,6 +12,7 @@ documentation:
 types:
   errors: !include raml-util/schemas/errors.schema
   emailEntity: !include email_entity.json
+  emailEntries: !include email_entity_collections.json
   configurations: !include configurations.json
 
 traits:
@@ -23,8 +24,13 @@ traits:
 resourceTypes:
   collection: !include raml-util/rtypes/collection.raml
   collection-item: !include raml-util/rtypes/item-collection.raml
+  collection-item-get: !include raml-util/rtypes/item-collection-get.raml
 
 /email:
+  type:
+    collection-item-get:
+      schema: emailEntries
+      exampleItem: !include examples/email.sample
   post:
     description: Send email notifications
     body:
@@ -46,3 +52,9 @@ resourceTypes:
         body:
           text/plain:
             example: "Internal server error"
+  get:
+    description: "Get emails"
+    is: [
+      searchable: {description: "searchable using CQL", example: "status==FAILURE"},
+      pageable
+    ]

--- a/ramls/email_entity.json
+++ b/ramls/email_entity.json
@@ -36,6 +36,30 @@
         "type": "object",
         "$ref": "attachment.json"
       }
+    },
+    "status": {
+      "description": "status of email",
+      "type": "string",
+      "enum": [
+        "DELIVERED",
+        "FAILURE",
+        "PROCESSING"
+      ],
+      "default": "DELIVERED"
+    },
+    "message": {
+      "description": "Server error message or other cause of the error",
+      "type": "string"
+    },
+    "date": {
+      "description": "The date the email was sent to the SMTP server",
+      "type": "string",
+      "format": "date-time"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes to email, provided by the server (client should not provide)",
+      "type" : "object",
+      "$ref" : "raml-util/schemas/metadata.schema"
     }
   },
   "required": [

--- a/ramls/email_entity_collections.json
+++ b/ramls/email_entity_collections.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description":"List of mail entries",
+  "properties": {
+    "emailEntity": {
+      "id": "email",
+      "type": "array",
+      "description":"Email Entity",
+      "items": {
+        "type": "object",
+        "$ref": "email_entity.json"
+      }
+    },
+    "totalRecords": {
+      "description": "total records",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/ramls/email_entity_collections.json
+++ b/ramls/email_entity_collections.json
@@ -17,5 +17,9 @@
       "type": "integer"
     }
   },
+  "required": [
+    "emailEntity",
+    "totalRecords"
+  ],
   "additionalProperties": true
 }

--- a/src/main/java/org/folio/rest/impl/DelayedTasksAPI.java
+++ b/src/main/java/org/folio/rest/impl/DelayedTasksAPI.java
@@ -24,18 +24,13 @@ public class DelayedTasksAPI extends AbstractEmail implements DelayedTask {
   @Override
   public void deleteDelayedTaskExpiredMessages(String expirationDate, String status, Map<String, String> headers,
                                                Handler<AsyncResult<Response>> resultHandler, Context context) {
-    try {
-      checkExpirationDate(expirationDate)
-        .compose(v -> determinateEmailStatus(status))
-        .compose(emailStatus -> deleteEmailsByExpirationDate(expirationDate, emailStatus))
-        .map(v -> DeleteDelayedTaskExpiredMessagesResponse.respond204WithTextPlain(Status.NO_CONTENT))
-        .map(Response.class::cast)
-        .otherwise(this::mapExceptionToResponse)
-        .setHandler(resultHandler);
-    } catch (Exception ex) {
-      logger.error(ex.getMessage(), ex);
-      resultHandler.handle(Future.succeededFuture(
-        DeleteDelayedTaskExpiredMessagesResponse.respond500WithTextPlain(ex)));
-    }
+    Future.succeededFuture()
+      .compose(v -> checkExpirationDate(expirationDate))
+      .compose(v -> determinateEmailStatus(status))
+      .compose(emailStatus -> deleteEmailsByExpirationDate(expirationDate, emailStatus))
+      .map(v -> DeleteDelayedTaskExpiredMessagesResponse.respond204WithTextPlain(Status.NO_CONTENT))
+      .map(Response.class::cast)
+      .otherwise(this::mapExceptionToResponse)
+      .setHandler(resultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/impl/DelayedTasksAPI.java
+++ b/src/main/java/org/folio/rest/impl/DelayedTasksAPI.java
@@ -1,0 +1,41 @@
+package org.folio.rest.impl;
+
+import static javax.ws.rs.core.Response.Status;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.impl.base.AbstractEmail;
+import org.folio.rest.jaxrs.resource.DelayedTask;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+
+public class DelayedTasksAPI extends AbstractEmail implements DelayedTask {
+
+  public DelayedTasksAPI(Vertx vertx, String tenantId) {
+    super(vertx, tenantId);
+  }
+
+  @Override
+  public void deleteDelayedTaskExpiredMessages(String expirationDate, String status, Map<String, String> headers,
+                                               Handler<AsyncResult<Response>> resultHandler, Context context) {
+    try {
+      checkExpirationDate(expirationDate)
+        .compose(v -> determinateEmailStatus(status))
+        .compose(emailStatus -> deleteEmailsByExpirationDate(expirationDate, emailStatus))
+        .map(v -> DeleteDelayedTaskExpiredMessagesResponse.respond204WithTextPlain(Status.NO_CONTENT))
+        .map(Response.class::cast)
+        .otherwise(this::mapExceptionToResponse)
+        .setHandler(resultHandler);
+    } catch (Exception ex) {
+      logger.error(ex.getMessage(), ex);
+      resultHandler.handle(Future.succeededFuture(
+        DeleteDelayedTaskExpiredMessagesResponse.respond500WithTextPlain(ex)));
+    }
+  }
+}

--- a/src/main/java/org/folio/rest/impl/EmailAPI.java
+++ b/src/main/java/org/folio/rest/impl/EmailAPI.java
@@ -12,9 +12,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 
 public class EmailAPI extends AbstractEmail implements Email {
 
@@ -25,35 +23,26 @@ public class EmailAPI extends AbstractEmail implements Email {
   @Override
   public void postEmail(EmailEntity entity, Map<String, String> requestHeaders,
                         Handler<AsyncResult<Response>> resultHandler, Context context) {
-    MultiMap caseInsensitiveHeaders = new CaseInsensitiveHeaders().addAll(requestHeaders);
-    try {
-      lookupConfig(caseInsensitiveHeaders)
-        .compose(conf -> checkConfiguration(conf, entity))
-        .compose(conf -> sendEmail(conf, entity))
-        .compose(this::saveEmail)
-        .map(PostEmailResponse::respond200WithTextPlain)
-        .map(Response.class::cast)
-        .otherwise(this::mapExceptionToResponse)
-        .setHandler(resultHandler);
-    } catch (Exception ex) {
-      logger.error(ex.getMessage(), ex);
-      resultHandler.handle(Future.succeededFuture(PostEmailResponse.respond500WithTextPlain(ex)));
-    }
+    Future.succeededFuture()
+      .compose(v -> lookupConfig(requestHeaders))
+      .compose(conf -> checkConfiguration(conf, entity))
+      .compose(conf -> sendEmail(conf, entity))
+      .compose(this::saveEmail)
+      .map(PostEmailResponse::respond200WithTextPlain)
+      .map(Response.class::cast)
+      .otherwise(this::mapExceptionToResponse)
+      .setHandler(resultHandler);
   }
 
   @Override
   public void getEmail(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders,
                        Handler<AsyncResult<Response>> resultHandler, Context context) {
-    try {
-      findEmailEntries(limit, offset, query)
-        .compose(this::mapJsonObjectToEmailEntries)
-        .map(GetEmailResponse::respond200WithApplicationJson)
-        .map(Response.class::cast)
-        .otherwise(this::mapExceptionToResponse)
-        .setHandler(resultHandler);
-    } catch (Exception ex) {
-      logger.error(ex.getMessage(), ex);
-      resultHandler.handle(Future.succeededFuture(GetEmailResponse.respond500WithTextPlain(ex)));
-    }
+    Future.succeededFuture()
+      .compose(v -> findEmailEntries(limit, offset, query))
+      .compose(this::mapJsonObjectToEmailEntries)
+      .map(GetEmailResponse::respond200WithApplicationJson)
+      .map(Response.class::cast)
+      .otherwise(this::mapExceptionToResponse)
+      .setHandler(resultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/impl/EmailAPI.java
+++ b/src/main/java/org/folio/rest/impl/EmailAPI.java
@@ -1,125 +1,78 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.*;
-import io.vertx.core.http.*;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import static org.folio.util.EmailUtils.REQUIREMENTS_CONFIG_SET;
+import static org.folio.util.EmailUtils.isIncorrectSmtpServerConfig;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.folio.rest.impl.base.AbstractEmail;
 import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.EmailEntity;
 import org.folio.rest.jaxrs.resource.Email;
-import org.folio.services.MailService;
+import org.folio.util.EmailUtils;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.util.Map;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.CaseInsensitiveHeaders;
 
-import static org.folio.rest.RestVerticle.*;
-import static org.folio.util.EmailUtils.*;
+public class EmailAPI extends AbstractEmail implements Email {
 
-public class EmailAPI implements Email {
-
-  private static final String REQUEST_URL_TEMPLATE = "%s/%s?query=module==%s";
-  private static final String REQUEST_URI_PATH = "configurations/entries";
-  private static final String HTTP_HEADER_ACCEPT = HttpHeaders.ACCEPT.toString();
-  private static final String HTTP_HEADER_CONTENT_TYPE = HttpHeaders.CONTENT_TYPE.toString();
-  private static final String OKAPI_URL_HEADER = "x-okapi-url";
-  private static final String MODULE_EMAIL_SMTP_SERVER = "SMTP_SERVER";
-  private static final String LOOKUP_TIMEOUT = "lookup.timeout";
-  private static final String LOOKUP_TIMEOUT_VAL = "1000";
-
-  private static final String ERROR_LOOKING_UP_MOD_CONFIG = "Error looking up config at url=%s | Expected status code 200, got %s | error message: %s";
-  private static final String ERROR_MIN_REQUIREMENT_MOD_CONFIG = "The 'mod-config' module doesn't have a minimum config for SMTP server, the min config is: %s";
-
-  private final Logger logger = LoggerFactory.getLogger(EmailAPI.class);
-  private final Vertx vertx;
-
-  private String tenantId;
-  private HttpClient httpClient;
-
-  /**
-   * Timeout to wait for response
-   */
-  private int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, LOOKUP_TIMEOUT_VAL));
-
-  public EmailAPI(final Vertx vertx, final String tenantId) {
-    this.tenantId = tenantId;
-    this.vertx = vertx;
-    initHttpClient();
-  }
-
-  /**
-   * init the http client to 'mod-config'
-   */
-  private void initHttpClient() {
-    HttpClientOptions options = new HttpClientOptions();
-    options.setConnectTimeout(lookupTimeout);
-    options.setIdleTimeout(lookupTimeout);
-    this.httpClient = vertx.createHttpClient(options);
+  public EmailAPI(Vertx vertx, String tenantId) {
+    super(vertx, tenantId);
   }
 
   @Override
-  public void postEmail(EmailEntity entity, Map<String, String> requestHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context context) {
+  public void postEmail(EmailEntity entity, Map<String, String> requestHeaders,
+                        Handler<AsyncResult<Response>> resultHandler, Context context) {
     MultiMap caseInsensitiveHeaders = new CaseInsensitiveHeaders().addAll(requestHeaders);
     try {
       lookupConfig(caseInsensitiveHeaders).setHandler(lookupConfigHandler -> {
         if (lookupConfigHandler.failed()) {
-          PostEmailResponse response = createResponse(Status.BAD_REQUEST, lookupConfigHandler.cause().getMessage());
-          asyncResultHandler.handle(Future.succeededFuture(response));
+          PostEmailResponse response = EmailUtils.createResponse(Status.BAD_REQUEST, lookupConfigHandler.cause().getMessage());
+          resultHandler.handle(Future.succeededFuture(response));
           return;
         }
         Configurations configurations = lookupConfigHandler.result().mapTo(Configurations.class);
-        if (checkMinConfigSmtpServer(configurations)) {
+        if (isIncorrectSmtpServerConfig(configurations)) {
           String errorMessage = String.format(ERROR_MIN_REQUIREMENT_MOD_CONFIG, REQUIREMENTS_CONFIG_SET);
           logger.error(errorMessage);
-          asyncResultHandler.handle(Future.succeededFuture(createResponse(Status.INTERNAL_SERVER_ERROR, errorMessage)));
+          resultHandler.handle(Future.succeededFuture(EmailUtils.createResponse(Status.INTERNAL_SERVER_ERROR, errorMessage)));
           return;
         }
 
-        MailService mailService = MailService.createProxy(vertx, MAIL_SERVICE_ADDRESS);
-        JsonObject congJson = JsonObject.mapFrom(configurations);
-        JsonObject entityJson = JsonObject.mapFrom(entity);
-        mailService.sendEmail(congJson, entityJson, result -> {
-          if (result.failed()) {
-            String errorMessage = result.cause().getMessage();
-            logger.error(errorMessage);
-            asyncResultHandler.handle(Future.succeededFuture(createResponse(Status.INTERNAL_SERVER_ERROR, errorMessage)));
-            return;
-          }
-          String message = result.result().getString(MESSAGE_RESULT);
-          asyncResultHandler.handle(Future.succeededFuture(createResponse(Status.OK, message)));
-        });
+        sendEmail(configurations, entity)
+          .compose(this::storeEmail)
+          .map(PostEmailResponse::respond200WithTextPlain)
+          .map(Response.class::cast)
+          .otherwise(this::mapExceptionToResponse)
+          .setHandler(resultHandler);
       });
     } catch (Exception ex) {
       logger.error(ex.getMessage(), ex);
-      asyncResultHandler.handle(Future.failedFuture(ex));
+      resultHandler.handle(Future.succeededFuture(PostEmailResponse.respond500WithTextPlain(ex)));
     }
   }
 
-  private Future<JsonObject> lookupConfig(MultiMap headers) {
-    Future<JsonObject> future = Future.future();
-    String okapiUrl = headers.get(OKAPI_URL_HEADER);
-    String okapiToken = headers.get(OKAPI_HEADER_TOKEN);
-    String requestUrl = String.format(REQUEST_URL_TEMPLATE, okapiUrl, REQUEST_URI_PATH, MODULE_EMAIL_SMTP_SERVER);
-    HttpClientRequest request = httpClient.getAbs(requestUrl);
-    request
-      .putHeader(OKAPI_HEADER_TOKEN, okapiToken)
-      .putHeader(OKAPI_HEADER_TENANT, tenantId)
-      .putHeader(HTTP_HEADER_CONTENT_TYPE, MediaType.APPLICATION_JSON)
-      .putHeader(HTTP_HEADER_ACCEPT, MediaType.APPLICATION_JSON)
-      .handler(response -> {
-        if (response.statusCode() != 200) {
-          response.bodyHandler(bufHandler ->
-            future.fail(String.format(ERROR_LOOKING_UP_MOD_CONFIG, requestUrl, response.statusCode(), bufHandler.toString())));
-        } else {
-          response.bodyHandler(bufHandler -> {
-            JsonObject resultObject = bufHandler.toJsonObject();
-            future.complete(resultObject);
-          });
-        }
-      });
-    request.end();
-    return future;
+  @Override
+  public void getEmail(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders,
+                       Handler<AsyncResult<Response>> resultHandler, Context context) {
+    try {
+      findEmailEntries(limit, offset, query)
+        .compose(this::mapJsonObjectToEmailEntries)
+        .map(GetEmailResponse::respond200WithApplicationJson)
+        .map(Response.class::cast)
+        .otherwise(this::mapExceptionToResponse)
+        .setHandler(resultHandler);
+    } catch (Exception ex) {
+      logger.error(ex.getMessage(), ex);
+      resultHandler.handle(Future.succeededFuture(GetEmailResponse.respond500WithTextPlain(ex)));
+    }
   }
 }

--- a/src/main/java/org/folio/rest/impl/EmailAPI.java
+++ b/src/main/java/org/folio/rest/impl/EmailAPI.java
@@ -1,18 +1,12 @@
 package org.folio.rest.impl;
 
-import static org.folio.util.EmailUtils.REQUIREMENTS_CONFIG_SET;
-import static org.folio.util.EmailUtils.isIncorrectSmtpServerConfig;
-
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 
 import org.folio.rest.impl.base.AbstractEmail;
-import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.EmailEntity;
 import org.folio.rest.jaxrs.resource.Email;
-import org.folio.util.EmailUtils;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -33,27 +27,14 @@ public class EmailAPI extends AbstractEmail implements Email {
                         Handler<AsyncResult<Response>> resultHandler, Context context) {
     MultiMap caseInsensitiveHeaders = new CaseInsensitiveHeaders().addAll(requestHeaders);
     try {
-      lookupConfig(caseInsensitiveHeaders).setHandler(lookupConfigHandler -> {
-        if (lookupConfigHandler.failed()) {
-          PostEmailResponse response = EmailUtils.createResponse(Status.BAD_REQUEST, lookupConfigHandler.cause().getMessage());
-          resultHandler.handle(Future.succeededFuture(response));
-          return;
-        }
-        Configurations configurations = lookupConfigHandler.result().mapTo(Configurations.class);
-        if (isIncorrectSmtpServerConfig(configurations)) {
-          String errorMessage = String.format(ERROR_MIN_REQUIREMENT_MOD_CONFIG, REQUIREMENTS_CONFIG_SET);
-          logger.error(errorMessage);
-          resultHandler.handle(Future.succeededFuture(EmailUtils.createResponse(Status.INTERNAL_SERVER_ERROR, errorMessage)));
-          return;
-        }
-
-        sendEmail(configurations, entity)
-          .compose(this::storeEmail)
-          .map(PostEmailResponse::respond200WithTextPlain)
-          .map(Response.class::cast)
-          .otherwise(this::mapExceptionToResponse)
-          .setHandler(resultHandler);
-      });
+      lookupConfig(caseInsensitiveHeaders)
+        .compose(conf -> checkConfiguration(conf, entity))
+        .compose(conf -> sendEmail(conf, entity))
+        .compose(this::saveEmail)
+        .map(PostEmailResponse::respond200WithTextPlain)
+        .map(Response.class::cast)
+        .otherwise(this::mapExceptionToResponse)
+        .setHandler(resultHandler);
     } catch (Exception ex) {
       logger.error(ex.getMessage(), ex);
       resultHandler.handle(Future.succeededFuture(PostEmailResponse.respond500WithTextPlain(ex)));

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -1,15 +1,22 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.*;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import io.vertx.serviceproxy.ServiceBinder;
-import org.folio.rest.resource.interfaces.InitAPI;
-import org.folio.services.MailService;
+import static org.folio.util.EmailUtils.MAIL_SERVICE_ADDRESS;
+import static org.folio.util.EmailUtils.STORAGE_SERVICE_ADDRESS;
 
 import java.lang.management.ManagementFactory;
 
-import static org.folio.util.EmailUtils.MAIL_SERVICE_ADDRESS;
+import org.folio.rest.resource.interfaces.InitAPI;
+import org.folio.services.email.MailService;
+import org.folio.services.storage.StorageService;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.serviceproxy.ServiceBinder;
 
 /**
  * Performs preprocessing operations before the verticle is deployed,
@@ -26,6 +33,9 @@ public class InitAPIs implements InitAPI {
     new ServiceBinder(vertx)
       .setAddress(MAIL_SERVICE_ADDRESS)
       .register(MailService.class, MailService.create(vertx));
+    new ServiceBinder(vertx)
+      .setAddress(STORAGE_SERVICE_ADDRESS)
+      .register(StorageService.class, StorageService.create(vertx));
 
     handler.handle(Future.succeededFuture(true));
   }

--- a/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
+++ b/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
@@ -1,0 +1,189 @@
+package org.folio.rest.impl.base;
+
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.util.EmailUtils.MAIL_SERVICE_ADDRESS;
+import static org.folio.util.EmailUtils.STORAGE_SERVICE_ADDRESS;
+import static org.folio.util.EmailUtils.findStatusByName;
+
+import java.util.regex.Pattern;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.jaxrs.model.Configurations;
+import org.folio.rest.jaxrs.model.EmailEntity;
+import org.folio.rest.jaxrs.model.EmailEntries;
+import org.folio.services.email.MailService;
+import org.folio.services.storage.StorageService;
+
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public abstract class AbstractEmail {
+
+  private static final String REQUEST_URL_TEMPLATE = "%s/%s?query=module==%s";
+  private static final String REQUEST_URI_PATH = "configurations/entries";
+  private static final String HTTP_HEADER_ACCEPT = HttpHeaders.ACCEPT.toString();
+  private static final String HTTP_HEADER_CONTENT_TYPE = HttpHeaders.CONTENT_TYPE.toString();
+  private static final String OKAPI_URL_HEADER = "x-okapi-url";
+  private static final String MODULE_EMAIL_SMTP_SERVER = "SMTP_SERVER";
+  private static final String LOOKUP_TIMEOUT = "lookup.timeout";
+  private static final String LOOKUP_TIMEOUT_VAL = "1000";
+
+  private static final Pattern DATE_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}$");
+  private static final String ERROR_LOOKING_UP_MOD_CONFIG = "Error looking up config at url=%s | Expected status code 200, got %s | error message: %s";
+  protected static final String ERROR_MIN_REQUIREMENT_MOD_CONFIG = "The 'mod-config' module doesn't have a minimum config for SMTP server, the min config is: %s";
+  private static final String ERROR_MESSAGE_INCORRECT_DATE_PARAMETER = "Invalid date value, the parameter must be in the format: yyyy-MM-dd";
+
+  protected final Logger logger = LoggerFactory.getLogger(AbstractEmail.class);
+  protected final Vertx vertx;
+  private String tenantId;
+
+  private HttpClient httpClient;
+  private MailService mailService;
+  private StorageService storageService;
+
+  /**
+   * Timeout to wait for response
+   */
+  private int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, LOOKUP_TIMEOUT_VAL));
+
+  public AbstractEmail(Vertx vertx, String tenantId) {
+    this.vertx = vertx;
+    this.tenantId = tenantId;
+    initHttpClient();
+    initServices();
+  }
+
+  /**
+   * Initialization of the email sending and storage service
+   */
+  private void initServices() {
+    mailService = MailService.createProxy(vertx, MAIL_SERVICE_ADDRESS);
+    storageService = StorageService.createProxy(vertx, STORAGE_SERVICE_ADDRESS);
+  }
+
+  /**
+   * init the http client to 'mod-config'
+   */
+  private void initHttpClient() {
+    HttpClientOptions options = new HttpClientOptions();
+    options.setConnectTimeout(lookupTimeout);
+    options.setIdleTimeout(lookupTimeout);
+    this.httpClient = vertx.createHttpClient(options);
+  }
+
+  protected Future<JsonObject> lookupConfig(MultiMap headers) {
+    Future<JsonObject> future = Future.future();
+    String okapiUrl = headers.get(OKAPI_URL_HEADER);
+    String okapiToken = headers.get(OKAPI_HEADER_TOKEN);
+    String requestUrl = String.format(REQUEST_URL_TEMPLATE, okapiUrl, REQUEST_URI_PATH, MODULE_EMAIL_SMTP_SERVER);
+    HttpClientRequest request = httpClient.getAbs(requestUrl);
+    request
+      .putHeader(OKAPI_HEADER_TOKEN, okapiToken)
+      .putHeader(OKAPI_HEADER_TENANT, tenantId)
+      .putHeader(HTTP_HEADER_CONTENT_TYPE, MediaType.APPLICATION_JSON)
+      .putHeader(HTTP_HEADER_ACCEPT, MediaType.APPLICATION_JSON)
+      .handler(response -> {
+        if (response.statusCode() != 200) {
+          response.bodyHandler(bufHandler ->
+            future.fail(String.format(ERROR_LOOKING_UP_MOD_CONFIG, requestUrl, response.statusCode(), bufHandler.toString())));
+        } else {
+          response.bodyHandler(bufHandler -> {
+            JsonObject resultObject = bufHandler.toJsonObject();
+            future.complete(resultObject);
+          });
+        }
+      });
+    request.end();
+    return future;
+  }
+
+  protected Future<JsonObject> sendEmail(Configurations configurations, EmailEntity entity) {
+    Future<JsonObject> future = Future.future();
+    JsonObject configJson = JsonObject.mapFrom(configurations);
+    JsonObject emailEntityJson = JsonObject.mapFrom(entity);
+    mailService.sendEmail(configJson, emailEntityJson, future);
+    return future;
+  }
+
+  protected Future<String> storeEmail(JsonObject emailEntityJson) {
+    Future<String> future = Future.future();
+    storageService.saveEmailEntity(tenantId, emailEntityJson, result -> {
+      if (result.failed()) {
+        future.fail(result.cause());
+        return;
+      }
+      EmailEntity emailEntity = emailEntityJson.mapTo(EmailEntity.class);
+      future.complete(emailEntity.getMessage());
+    });
+    return future;
+  }
+
+  protected Future<JsonObject> findEmailEntries(int limit, int offset, String query) {
+    Future<JsonObject> future = Future.future();
+    storageService.findEmailEntries(tenantId, limit, offset, query, future);
+    return future;
+  }
+
+  protected Future<EmailEntries> mapJsonObjectToEmailEntries(JsonObject emailEntriesJson) {
+    return Future.succeededFuture(emailEntriesJson.mapTo(EmailEntries.class));
+  }
+
+  protected Future<Void> deleteEmailsByExpirationDate(String expirationDate, String emailStatus) {
+    Future<Void> future = Future.future();
+    storageService.deleteEmailEntriesByExpirationDateAndStatus(tenantId, expirationDate, emailStatus,
+      result -> {
+        if (result.failed()) {
+          future.fail(result.cause());
+          return;
+        }
+        future.complete();
+      });
+    return future;
+  }
+
+  protected Future<String> determinateEmailStatus(String emailStatus) {
+    Future<String> future = Future.future();
+    String status = StringUtils.isBlank(emailStatus)
+      ? EmailEntity.Status.DELIVERED.value()
+      : findStatusByName(emailStatus);
+    future.complete(status);
+    return future;
+  }
+
+  protected Future<Void> checkExpirationDate(String expirationDate) {
+    Future<Void> future = Future.future();
+    if (StringUtils.isBlank(expirationDate) || isCorrectDateFormat(expirationDate)) {
+      future.complete();
+    } else {
+      future.fail(new IllegalArgumentException(ERROR_MESSAGE_INCORRECT_DATE_PARAMETER));
+    }
+    return future;
+  }
+
+  protected Response mapExceptionToResponse(Throwable t) {
+    logger.error(t.getMessage(), t);
+    return Response.status(500)
+      .header(CONTENT_TYPE, TEXT_PLAIN)
+      .entity(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
+      .build();
+  }
+
+  private boolean isCorrectDateFormat(String expirationDate) {
+    return DATE_PATTERN.matcher(expirationDate).matches();
+  }
+}

--- a/src/main/java/org/folio/services/email/MailService.java
+++ b/src/main/java/org/folio/services/email/MailService.java
@@ -1,11 +1,12 @@
-package org.folio.services;
+package org.folio.services.email;
+
+import org.folio.services.email.impl.MailServiceImpl;
 
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import org.folio.services.impl.MailServiceImpl;
 
 /**
  * The service provides the ability to send email using the SMTP server

--- a/src/main/java/org/folio/services/email/package-info.java
+++ b/src/main/java/org/folio/services/email/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(groupPackage = "org.folio.services.email", name = "mail-service")
+package org.folio.services.email;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/src/main/java/org/folio/services/package-info.java
+++ b/src/main/java/org/folio/services/package-info.java
@@ -1,4 +1,0 @@
-@ModuleGen(groupPackage = "org.folio.services", name = "mail-service")
-package org.folio.services;
-
-import io.vertx.codegen.annotations.ModuleGen;

--- a/src/main/java/org/folio/services/storage/StorageService.java
+++ b/src/main/java/org/folio/services/storage/StorageService.java
@@ -1,0 +1,56 @@
+package org.folio.services.storage;
+
+import org.folio.services.storage.impl.StorageServiceImpl;
+
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * The interface provides basic CRUD operations for storing and retrieving data from the storage
+ */
+@ProxyGen
+public interface StorageService {
+
+  static StorageService create(Vertx vertx) {
+    return new StorageServiceImpl(vertx);
+  }
+
+  /**
+   * Creates proxy instance that helps to push message into the message queue
+   *
+   * @param vertx   vertx instance
+   * @param address host address
+   * @return StorageService instance
+   */
+  static StorageService createProxy(Vertx vertx, String address) {
+    return new StorageServiceVertxEBProxy(vertx, address);
+  }
+
+  /**
+   * Persists an emailEntityJson object to the database for metrics
+   *
+   * @param emailEntityJson the object contains an {@link org.folio.rest.jaxrs.model.EmailEntity}
+   *                        entity representation in a JSON format
+   */
+  void saveEmailEntity(String tenantId, JsonObject emailEntityJson,
+                       Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
+   * Find all EmailEntries by query
+   * The query parameter may contain email status, expiration date or other parameters
+   */
+  void findEmailEntries(String tenantId, int limit, int offset, String query,
+                        Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
+   * Delete EmailEntries by expiration date and email status
+   *
+   * @param expirationDate the expiration date of email in format: `yyyy-MM-dd`
+   * @param emailStatus    the status of email {@link org.folio.rest.jaxrs.model.EmailEntity.Status}
+   */
+  void deleteEmailEntriesByExpirationDateAndStatus(String tenantId, String expirationDate, String emailStatus,
+                                                   Handler<AsyncResult<JsonObject>> resultHandler);
+}

--- a/src/main/java/org/folio/services/storage/impl/StorageServiceImpl.java
+++ b/src/main/java/org/folio/services/storage/impl/StorageServiceImpl.java
@@ -1,0 +1,125 @@
+package org.folio.services.storage.impl;
+
+import static org.folio.util.EmailUtils.EMAIL_STATISTICS_TABLE_NAME;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.jaxrs.model.EmailEntity;
+import org.folio.rest.jaxrs.model.EmailEntries;
+import org.folio.rest.persist.Criteria.Limit;
+import org.folio.rest.persist.Criteria.Offset;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.rest.persist.interfaces.Results;
+import org.folio.services.storage.StorageService;
+import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
+import org.z3950.zing.cql.cql2pgjson.FieldException;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class StorageServiceImpl implements StorageService {
+
+  private static final Logger logger = LoggerFactory.getLogger(StorageServiceImpl.class);
+
+  private static final String DELETE_QUERY_BY_DATE = "DELETE FROM %1$s WHERE (jsonb->>'date')::date <= ('%2$s')::date AND jsonb->>'status' = '%3$s'";
+  private static final String DELETE_QUERY_INTERVAL_ONE_DAY = "DELETE FROM %1$s WHERE (jsonb->>'date')::date < CURRENT_DATE - INTERVAL '1' DAY AND jsonb->>'status' = '%2$s'";
+  private static final String COLUMN_EXTENSION = ".jsonb";
+
+  private final Vertx vertx;
+
+  public StorageServiceImpl(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  public void saveEmailEntity(String tenantId, JsonObject emailEntityJson,
+                              Handler<AsyncResult<JsonObject>> resultHandler) {
+    try {
+      EmailEntity emailEntity = emailEntityJson.mapTo(EmailEntity.class);
+      PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
+      pgClient.save(EMAIL_STATISTICS_TABLE_NAME, emailEntity,
+        postReply -> {
+          if (postReply.failed()) {
+            errorHandler(postReply.cause(), resultHandler);
+            return;
+          }
+          resultHandler.handle(Future.succeededFuture());
+        });
+    } catch (Exception ex) {
+      errorHandler(ex, resultHandler);
+    }
+  }
+
+  @Override
+  public void findEmailEntries(String tenantId, int limit, int offset, String query,
+                               Handler<AsyncResult<JsonObject>> resultHandler) {
+    try {
+      String[] fieldList = {"*"};
+      CQLWrapper cql = getCQL(query, limit, offset);
+      PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
+      pgClient.get(EMAIL_STATISTICS_TABLE_NAME, EmailEntity.class, fieldList, cql, true, false,
+        getReply -> {
+          if (getReply.failed()) {
+            errorHandler(getReply.cause(), resultHandler);
+            return;
+          }
+
+          Results<EmailEntity> result = getReply.result();
+          Integer totalRecords = result.getResultInfo().getTotalRecords();
+          EmailEntries emailEntries = new EmailEntries()
+            .withEmailEntity(result.getResults())
+            .withTotalRecords(totalRecords);
+
+          JsonObject entries = JsonObject.mapFrom(emailEntries);
+          resultHandler.handle(Future.succeededFuture(entries));
+        });
+    } catch (Exception ex) {
+      errorHandler(ex, resultHandler);
+    }
+  }
+
+  @Override
+  public void deleteEmailEntriesByExpirationDateAndStatus(String tenantId, String expirationDate, String status,
+                                                          Handler<AsyncResult<JsonObject>> resultHandler) {
+    try {
+      String fullTableName = String.format("%s.%s", PostgresClient.convertToPsqlStandard(tenantId), EMAIL_STATISTICS_TABLE_NAME);
+      String query = StringUtils.isBlank(expirationDate)
+        ? String.format(DELETE_QUERY_INTERVAL_ONE_DAY, fullTableName, status)
+        : String.format(DELETE_QUERY_BY_DATE, fullTableName, expirationDate, status);
+
+      PostgresClient.getInstance(vertx, tenantId).execute(query, result -> {
+        if (result.failed()) {
+          errorHandler(result.cause(), resultHandler);
+          return;
+        }
+        resultHandler.handle(Future.succeededFuture());
+      });
+    } catch (Exception ex) {
+      errorHandler(ex, resultHandler);
+    }
+  }
+
+  private void errorHandler(Throwable ex, Handler<AsyncResult<JsonObject>> asyncResultHandler) {
+    logger.error(ex.getMessage(), ex);
+    asyncResultHandler.handle(Future.failedFuture(ex));
+  }
+
+  /**
+   * Build CQL from request URL query
+   *
+   * @param query - query from URL
+   * @param limit - limit of records for pagination
+   * @return - CQL wrapper for building postgres request to database
+   */
+  private CQLWrapper getCQL(String query, int limit, int offset) throws FieldException {
+    CQL2PgJSON cql2pgJson = new CQL2PgJSON(EMAIL_STATISTICS_TABLE_NAME + COLUMN_EXTENSION);
+    return new CQLWrapper(cql2pgJson, query)
+      .setLimit(new Limit(limit))
+      .setOffset(new Offset(offset));
+  }
+}

--- a/src/main/java/org/folio/services/storage/package-info.java
+++ b/src/main/java/org/folio/services/storage/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(groupPackage = "org.folio.services.storage", name = "storage-service")
+package org.folio.services.storage;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/src/main/java/org/folio/util/EmailUtils.java
+++ b/src/main/java/org/folio/util/EmailUtils.java
@@ -13,14 +13,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.ws.rs.core.Response.Status;
-
 import org.apache.commons.lang3.StringUtils;
 import org.folio.enums.SmtpEmail;
 import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.EmailEntity;
-import org.folio.rest.jaxrs.resource.Email.PostEmailResponse;
 
 import io.vertx.ext.mail.LoginOption;
 import io.vertx.ext.mail.StartTLSOptions;
@@ -49,20 +46,10 @@ public class EmailUtils {
    */
   public static boolean isIncorrectSmtpServerConfig(Configurations configurations) {
     Set<String> configSet = configurations.getConfigs().stream()
+      .filter(conf -> StringUtils.isNotEmpty(conf.getValue()))
       .map(val -> val.getCode().toUpperCase())
       .collect(Collectors.toSet());
     return !configSet.containsAll(REQUIREMENTS_CONFIG_SET);
-  }
-
-  public static PostEmailResponse createResponse(Status status, String message) {
-    switch (status) {
-      case OK:
-        return PostEmailResponse.respond200WithTextPlain(message);
-      case BAD_REQUEST:
-        return PostEmailResponse.respond400WithTextPlain(message);
-      default:
-        return PostEmailResponse.respond500WithTextPlain("Internal Server Error");
-    }
   }
 
   /**

--- a/src/main/java/org/folio/util/EmailUtils.java
+++ b/src/main/java/org/folio/util/EmailUtils.java
@@ -1,27 +1,35 @@
 package org.folio.util;
 
-import io.vertx.ext.mail.LoginOption;
-import io.vertx.ext.mail.StartTLSOptions;
-import org.apache.commons.lang3.StringUtils;
-import org.folio.enums.SmtpEmail;
-import org.folio.rest.jaxrs.model.Config;
-import org.folio.rest.jaxrs.model.Configurations;
-import org.folio.rest.jaxrs.resource.Email.PostEmailResponse;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toSet;
+import static org.folio.enums.SmtpEmail.EMAIL_PASSWORD;
+import static org.folio.enums.SmtpEmail.EMAIL_SMTP_HOST;
+import static org.folio.enums.SmtpEmail.EMAIL_SMTP_PORT;
+import static org.folio.enums.SmtpEmail.EMAIL_USERNAME;
 
-import javax.ws.rs.core.Response.Status;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.toSet;
-import static org.folio.enums.SmtpEmail.*;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.enums.SmtpEmail;
+import org.folio.rest.jaxrs.model.Config;
+import org.folio.rest.jaxrs.model.Configurations;
+import org.folio.rest.jaxrs.model.EmailEntity;
+import org.folio.rest.jaxrs.resource.Email.PostEmailResponse;
+
+import io.vertx.ext.mail.LoginOption;
+import io.vertx.ext.mail.StartTLSOptions;
 
 public class EmailUtils {
 
   public static final String MAIL_SERVICE_ADDRESS = "mail-service.queue";
-  public static final String MESSAGE_RESULT = "result";
+  public static final String STORAGE_SERVICE_ADDRESS = "storage-service.queue";
+  public static final String EMAIL_STATISTICS_TABLE_NAME = "email_statistics";
 
   private EmailUtils() {
     //not called
@@ -39,7 +47,7 @@ public class EmailUtils {
    *
    * @return true if the configuration doesn't satisfy the minimum SMTP configs for sending the email
    */
-  public static boolean checkMinConfigSmtpServer(Configurations configurations) {
+  public static boolean isIncorrectSmtpServerConfig(Configurations configurations) {
     Set<String> configSet = configurations.getConfigs().stream()
       .map(val -> val.getCode().toUpperCase())
       .collect(Collectors.toSet());
@@ -92,5 +100,13 @@ public class EmailUtils {
       .map(Config::getValue)
       .findFirst()
       .orElse(StringUtils.EMPTY);
+  }
+
+  public static String findStatusByName(String name) {
+    return Arrays.stream(EmailEntity.Status.values())
+      .filter(status -> status.name().equalsIgnoreCase(name))
+      .map(EmailEntity.Status::value)
+      .findFirst()
+      .orElse(EmailEntity.Status.DELIVERED.value());
   }
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,0 +1,18 @@
+{
+  "scripts": [],
+  "tables": [
+    {
+      "tableName": "email_statistics",
+      "generateId": true,
+      "fromModuleVersion": "1.0",
+      "withMetadata": true,
+      "pkColumnName": "_id",
+      "index": [
+        {
+          "fieldName": "id",
+          "tOps": "ADD"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/java/org/folio/rest/impl/EmailAPITest.java
+++ b/src/test/java/org/folio/rest/impl/EmailAPITest.java
@@ -106,7 +106,7 @@ public class EmailAPITest {
 
     getResponse(okapiUrl, okapiEmailEntity)
       .then()
-      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
       .header(OKAPI_HEADER_TENANT, OKAPI_TENANT)
       .header(OKAPI_URL, okapiUrl)
       .header(OKAPI_HEADER_TOKEN, OKAPI_TOKEN);

--- a/src/test/java/org/folio/rest/impl/GettingMetricsTest.java
+++ b/src/test/java/org/folio/rest/impl/GettingMetricsTest.java
@@ -1,0 +1,151 @@
+package org.folio.rest.impl;
+
+import static org.folio.rest.jaxrs.model.EmailEntity.Status.DELIVERED;
+import static org.folio.rest.jaxrs.model.EmailEntity.Status.FAILURE;
+import static org.folio.util.StubUtils.getIncorrectWiserMockConfigurations;
+import static org.folio.util.StubUtils.getWiserMockConfigurations;
+import static org.folio.util.StubUtils.initModConfigStub;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.folio.rest.impl.base.AbstractAPITest;
+import org.folio.rest.jaxrs.model.EmailEntity;
+import org.junit.Test;
+
+import io.restassured.response.Response;
+
+public class GettingMetricsTest extends AbstractAPITest {
+
+  @Test
+  public void testDelayedTaskExpiredEmailWithDateAndDeliveredStatus() {
+    Response response = getEmails(DELIVERED.value())
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .extract()
+      .response();
+
+    List<EmailEntity> actualEntries = convertEntriesToJson(response).getEmailEntity();
+    assertEquals(0, actualEntries.size());
+
+    deleteEmailByDateAndStatus(generateExpirationDate(), DELIVERED.value())
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT)
+      .extract()
+      .response();
+  }
+
+  @Test
+  public void testDelayedTaskExpiredEmailWithDateAndFailureStatus() {
+    Response response = getEmails(FAILURE.value())
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .extract()
+      .response();
+
+    List<EmailEntity> actualEntries = convertEntriesToJson(response).getEmailEntity();
+    assertEquals(0, actualEntries.size());
+
+    deleteEmailByDateAndStatus(generateExpirationDate(), FAILURE.value())
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT)
+      .extract()
+      .response();
+  }
+
+  @Test
+  public void testDelayedTasks() {
+    String emptyVal = StringUtils.EMPTY;
+    String incorrectDate = "INCORRECT_DATE";
+
+    deleteEmailByDateAndStatus(generateExpirationDate(), emptyVal)
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT)
+      .extract()
+      .response();
+
+    deleteEmailByDateAndStatus(incorrectDate, emptyVal)
+      .then()
+      .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+      .extract()
+      .response();
+
+    deleteEmailByDateAndStatus(emptyVal, FAILURE.value())
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT)
+      .extract()
+      .response();
+
+    deleteEmailByDateAndStatus(emptyVal, incorrectDate)
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT)
+      .extract()
+      .response();
+  }
+
+  @Test
+  public void testSendEmailsWithDeliveredStatus() {
+    int mockServerPort = userMockServer.port();
+    initModConfigStub(mockServerPort, getWiserMockConfigurations());
+
+    EmailEntity emailOne = sendEmails();
+    EmailEntity emailTwo = sendEmails();
+    EmailEntity emailThree = sendEmails();
+
+    // check email on DB
+    checkStoredEmailsInDb(emailOne, DELIVERED);
+    checkStoredEmailsInDb(emailTwo, DELIVERED);
+    checkStoredEmailsInDb(emailThree, DELIVERED);
+
+    // delete all delivered email
+    deleteEmailByDateAndStatus(generateExpirationDate(), DELIVERED.value())
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT)
+      .extract()
+      .response();
+
+    // find all delivered email
+    Response response = getEmails(DELIVERED.value())
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .extract()
+      .response();
+
+    List<EmailEntity> actualEntries = convertEntriesToJson(response).getEmailEntity();
+    assertEquals(0, actualEntries.size());
+  }
+
+  @Test
+  public void testSendEmailsWithFailureStatus() {
+    int mockServerPort = userMockServer.port();
+    initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
+
+    EmailEntity emailOne = sendEmails();
+    EmailEntity emailTwo = sendEmails();
+    EmailEntity emailThree = sendEmails();
+
+    // check email on DB
+    checkStoredEmailsInDb(emailOne, FAILURE);
+    checkStoredEmailsInDb(emailTwo, FAILURE);
+    checkStoredEmailsInDb(emailThree, FAILURE);
+
+    // delete all failure email
+    deleteEmailByDateAndStatus(generateExpirationDate(), FAILURE.value())
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT)
+      .extract()
+      .response();
+
+    // find all failure email
+    Response response = getEmails(FAILURE.value())
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .extract()
+      .response();
+
+    List<EmailEntity> actualEntries = convertEntriesToJson(response).getEmailEntity();
+    assertEquals(0, actualEntries.size());
+  }
+}

--- a/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
+++ b/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
@@ -273,7 +273,7 @@ public abstract class AbstractAPITest {
   /**
    * Send random email
    */
-  protected EmailEntity sendEmails() {
+  protected EmailEntity sendEmails(int expectedStatusCode) {
     String sender = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
     String recipient = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
     String msg = "Test text for the message. Random text: " + RandomStringUtils.randomAlphabetic(20);
@@ -288,7 +288,7 @@ public abstract class AbstractAPITest {
 
     sendEmail(emailEntity)
       .then()
-      .statusCode(HttpStatus.SC_OK)
+      .statusCode(expectedStatusCode)
       .extract()
       .response();
 

--- a/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
+++ b/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
@@ -1,0 +1,314 @@
+package org.folio.rest.impl.base;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.rest.jaxrs.model.EmailEntity.Status;
+import static org.folio.util.EmailUtils.EMAIL_STATISTICS_TABLE_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import javax.mail.Address;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.http.HttpStatus;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.EmailEntity;
+import org.folio.rest.jaxrs.model.EmailEntries;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.subethamail.wiser.Wiser;
+import org.subethamail.wiser.WiserMessage;
+
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.response.Response;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import junit.framework.AssertionFailedError;
+
+@RunWith(VertxUnitRunner.class)
+public abstract class AbstractAPITest {
+
+  private static final Logger logger = LoggerFactory.getLogger(AbstractAPITest.class);
+
+  private static final int DEFAULT_LIMIT = 100;
+  private static final String HTTP_PORT = "http.port";
+  private static final String TENANT_CLIENT_HOST = " http://%s:%s";
+
+  private static final String OKAPI_TENANT = "test_tenant";
+  private static final String OKAPI_TOKEN = "test_token";
+  private static final String OKAPI_URL_HEADER = "x-okapi-url";
+  private static final String OKAPI_HOST = "localhost";
+  private static final String OKAPI_URL_TEMPLATE = "http://localhost:%s";
+
+  private static final String REST_PATH_GET_EMAILS = "/email";
+  private static final String REST_PATH_WITH_QUERY = "%s?query=status=%s&limit=%s";
+
+  protected static final String ADDRESS_TEMPLATE = "%s@localhost";
+  private static final String SUCCESS_SEND_EMAIL = "The message has been delivered to %s";
+  private static final String MESSAGE_NOT_FOUND = "The message for the sender: `%s` was not found on the SMTP server";
+  protected static final String FAIL_SENDING_EMAIL = "Error in the 'mod-email' module, the module didn't send email | message:";
+
+  private static final String REST_DELETE_BATCH_EMAILS = "/delayedTask/expiredMessages";
+  private static final String REST_PATH_DELETE_BATCH_EMAILS = "%s?expirationDate=%s&emailStatus=%s";
+
+  private static Wiser wiser;
+  private static Vertx vertx;
+  private static int port;
+
+  @Rule
+  public Timeout rule = Timeout.seconds(100);
+
+  @Rule
+  public WireMockRule userMockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new ConsoleNotifier(true)));
+
+  @BeforeClass
+  public static void setUpClass(final TestContext context) throws Exception {
+    Async async = context.async();
+    vertx = Vertx.vertx();
+    port = NetworkUtils.nextFreePort();
+
+    wiser = new Wiser();
+    wiser.setPort(2500);
+
+    PostgresClient.setIsEmbedded(true);
+    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
+
+    TenantClient tenantClient = new TenantClient(String.format(TENANT_CLIENT_HOST, OKAPI_HOST, port), OKAPI_TENANT, OKAPI_TOKEN);
+    DeploymentOptions restDeploymentOptions = new DeploymentOptions()
+      .setConfig(new JsonObject().put(HTTP_PORT, port));
+
+    vertx.deployVerticle(RestVerticle.class.getName(), restDeploymentOptions,
+      res -> {
+        try {
+          tenantClient.postTenant(null, res2 -> {
+              wiser.start();
+              async.complete();
+            }
+          );
+        } catch (Exception e) {
+          logger.error(e.getMessage());
+        }
+      });
+  }
+
+  @AfterClass
+  public static void tearDownClass(final TestContext context) {
+    Async async = context.async();
+    vertx.close(context.asyncAssertSuccess(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      wiser.stop();
+      async.complete();
+    }));
+  }
+
+  @Before
+  public void setUp(TestContext context) {
+    Async async = context.async();
+    PostgresClient.getInstance(vertx, OKAPI_TENANT).delete(EMAIL_STATISTICS_TABLE_NAME, new Criterion(),
+      event -> {
+        if (event.failed()) {
+          logger.error(event.cause());
+          context.fail(event.cause());
+        } else {
+          async.complete();
+        }
+      });
+  }
+
+  /**
+   * Get emails by status
+   */
+  protected Response getEmails(String status) {
+    String okapiUrl = String.format(OKAPI_URL_TEMPLATE, userMockServer.port());
+    return RestAssured.given()
+      .port(port)
+      .contentType(MediaType.APPLICATION_JSON)
+      .header(new Header(OKAPI_HEADER_TENANT, OKAPI_TENANT))
+      .header(new Header(OKAPI_URL_HEADER, okapiUrl))
+      .header(new Header(OKAPI_HEADER_TOKEN, OKAPI_TOKEN))
+      .when()
+      .get(String.format(REST_PATH_WITH_QUERY, REST_PATH_GET_EMAILS, status, DEFAULT_LIMIT));
+  }
+
+  /**
+   * Send email notifications
+   */
+  protected Response sendEmail(EmailEntity emailEntity) {
+    String okapiUrl = String.format(OKAPI_URL_TEMPLATE, userMockServer.port());
+    return RestAssured.given()
+      .port(port)
+      .contentType(MediaType.APPLICATION_JSON)
+      .header(new Header(OKAPI_HEADER_TENANT, OKAPI_TENANT))
+      .header(new Header(OKAPI_URL_HEADER, okapiUrl))
+      .header(new Header(OKAPI_HEADER_TOKEN, OKAPI_TOKEN))
+      .body(JsonObject.mapFrom(emailEntity).toString())
+      .when()
+      .post(REST_PATH_GET_EMAILS);
+  }
+
+  /**
+   * Delete email by expirationDate and status
+   */
+  protected Response deleteEmailByDateAndStatus(String expirationDate, String status) {
+    String okapiUrl = String.format(OKAPI_URL_TEMPLATE, userMockServer.port());
+    return RestAssured.given()
+      .port(port)
+      .header(new Header(OKAPI_HEADER_TENANT, OKAPI_TENANT))
+      .header(new Header(OKAPI_URL_HEADER, okapiUrl))
+      .header(new Header(OKAPI_HEADER_TOKEN, OKAPI_TOKEN))
+      .when()
+      .delete(String.format(REST_PATH_DELETE_BATCH_EMAILS, REST_DELETE_BATCH_EMAILS, expirationDate, status));
+  }
+
+  /**
+   * Check that after sending the email successfully, it contains the email address of the recipient
+   */
+  protected void checkResponseMessage(Response response, String recipient) {
+    String responseMessage = response.getBody().asString();
+    assertEquals(String.format(SUCCESS_SEND_EMAIL, recipient), responseMessage);
+  }
+
+  /**
+   * Find the sent email message on the SMTP server by the sender
+   */
+  protected WiserMessage findMessageOnWiserServer(String sender) {
+    return wiser.getMessages().stream()
+      .filter(msg -> {
+        try {
+          return isContainsSenderAddress(sender, msg.getMimeMessage().getFrom());
+        } catch (MessagingException ex) {
+          logger.debug(ex);
+          throw throwAssertionFailedError(sender);
+        }
+      })
+      .findFirst()
+      .orElseThrow(() -> throwAssertionFailedError(sender));
+  }
+
+  private AssertionFailedError throwAssertionFailedError(String sender) {
+    return new AssertionFailedError(String.format(MESSAGE_NOT_FOUND, sender));
+  }
+
+  /**
+   * Check on the SMTP server that the email was sent successfully.
+   */
+  protected void checkMessagesOnWiserServer(WiserMessage wiserMessage,
+                                            EmailEntity emailEntity) throws MessagingException {
+
+    assertTrue(wiserMessage.toString().contains(emailEntity.getBody()));
+
+    MimeMessage message = wiserMessage.getMimeMessage();
+    assertEquals(emailEntity.getHeader(), message.getSubject());
+
+    Address[] from = message.getFrom();
+    checkAddress(emailEntity.getFrom(), from);
+
+    Address[] recipients = message.getAllRecipients();
+    checkAddress(emailEntity.getTo(), recipients);
+  }
+
+  /**
+   * Check stored emails in the database
+   */
+  protected void checkStoredEmailsInDb(EmailEntity emailEntity, Status status) {
+    Response responseDb = getEmails(status.value())
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .extract()
+      .response();
+
+    List<EmailEntity> emailEntities = convertEntriesToJson(responseDb).getEmailEntity();
+    Optional<EmailEntity> emailEntityOpt = emailEntities.stream().filter(entity -> emailEntity.getTo().equals(entity.getTo())).findFirst();
+    if (!emailEntityOpt.isPresent()) {
+      fail();
+    }
+    EmailEntity entity = emailEntityOpt.get();
+
+    assertEquals(emailEntity.getNotificationId(), entity.getNotificationId());
+    assertEquals(emailEntity.getTo(), entity.getTo());
+    assertEquals(emailEntity.getFrom(), entity.getFrom());
+    assertEquals(emailEntity.getHeader(), entity.getHeader());
+    assertEquals(emailEntity.getOutputFormat(), entity.getOutputFormat());
+    assertEquals(emailEntity.getBody(), entity.getBody());
+
+  }
+
+  /**
+   * Send random email
+   */
+  protected EmailEntity sendEmails() {
+    String sender = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
+    String recipient = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
+    String msg = "Test text for the message. Random text: " + RandomStringUtils.randomAlphabetic(20);
+
+    EmailEntity emailEntity = new EmailEntity()
+      .withNotificationId("1")
+      .withTo(recipient)
+      .withFrom(sender)
+      .withHeader("Reset password")
+      .withBody(msg)
+      .withOutputFormat(MediaType.TEXT_PLAIN);
+
+    sendEmail(emailEntity)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .extract()
+      .response();
+
+    return emailEntity;
+  }
+
+  protected String generateExpirationDate() {
+    SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+    df.setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC));
+    return df.format(new Date());
+  }
+
+  protected EmailEntries convertEntriesToJson(Response response) {
+    return new JsonObject(response.getBody().print()).mapTo(EmailEntries.class);
+  }
+
+  private void checkAddress(String expectedAddress, Address[] address) {
+    assertTrue(isContainsSenderAddress(expectedAddress, address));
+  }
+
+  private boolean isContainsSenderAddress(String sender, Address[] address) {
+    return Arrays.stream(address)
+      .map(Address::toString).
+        anyMatch(ad -> ad.equals(sender));
+  }
+}

--- a/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
+++ b/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
@@ -213,7 +213,7 @@ public abstract class AbstractAPITest {
           return isContainsSenderAddress(sender, msg.getMimeMessage().getFrom());
         } catch (MessagingException ex) {
           logger.debug(ex);
-          throw throwAssertionFailedError(sender);
+          return false;
         }
       })
       .findFirst()
@@ -221,7 +221,7 @@ public abstract class AbstractAPITest {
   }
 
   private AssertionFailedError throwAssertionFailedError(String sender) {
-    return new AssertionFailedError(String.format(MESSAGE_NOT_FOUND, sender));
+    throw new AssertionFailedError(String.format(MESSAGE_NOT_FOUND, sender));
   }
 
   /**

--- a/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
+++ b/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
@@ -22,6 +22,7 @@ import javax.mail.internet.MimeMessage;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
@@ -265,6 +266,8 @@ public abstract class AbstractAPITest {
     assertEquals(emailEntity.getOutputFormat(), entity.getOutputFormat());
     assertEquals(emailEntity.getBody(), entity.getBody());
 
+    assertTrue(StringUtils.isNoneBlank(entity.getMessage()));
+    assertTrue(StringUtils.isNoneBlank(entity.getStatus().value()));
   }
 
   /**

--- a/src/test/java/org/folio/util/EmailUtilsTest.java
+++ b/src/test/java/org/folio/util/EmailUtilsTest.java
@@ -1,19 +1,20 @@
 package org.folio.util;
 
-import org.folio.enums.SmtpEmail;
-import org.folio.rest.jaxrs.model.Config;
-import org.folio.rest.jaxrs.model.Configurations;
-import org.folio.rest.jaxrs.resource.Email;
-import org.folio.services.MailService;
-import org.junit.Test;
-
-import javax.ws.rs.core.Response.Status;
-import java.util.Collections;
-
 import static junit.framework.TestCase.fail;
 import static org.folio.util.EmailUtils.getEmailConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.folio.enums.SmtpEmail;
+import org.folio.rest.jaxrs.model.Config;
+import org.folio.rest.jaxrs.model.Configurations;
+import org.folio.rest.jaxrs.resource.Email;
+import org.folio.services.email.MailService;
+import org.junit.Test;
 
 public class EmailUtilsTest {
 
@@ -22,15 +23,15 @@ public class EmailUtilsTest {
     String message = "test message";
     verifyResponse(EmailUtils.createResponse(Status.OK, message), 200, message);
     verifyResponse(EmailUtils.createResponse(Status.BAD_REQUEST, message), 400, message);
-    verifyResponse(EmailUtils.createResponse(Status.INTERNAL_SERVER_ERROR, message), 500, "Internal Server Error");
+    verifyResponse(EmailUtils.createResponse(Status.INTERNAL_SERVER_ERROR, message), 500, Status.INTERNAL_SERVER_ERROR.getReasonPhrase());
   }
 
   @Test
   public void testMethodCheckMinConfigSmtpServer() {
     Configurations conf = new Configurations();
 
-    boolean isFullMinConfigForServer = EmailUtils.checkMinConfigSmtpServer(conf);
-    assertTrue(isFullMinConfigForServer);
+    boolean isIncorrectOrEmpty = EmailUtils.isIncorrectSmtpServerConfig(conf);
+    assertTrue(isIncorrectOrEmpty);
   }
 
   private void verifyResponse(Email.PostEmailResponse response, int expectedStatusCode, String expectedMsg) {

--- a/src/test/java/org/folio/util/EmailUtilsTest.java
+++ b/src/test/java/org/folio/util/EmailUtilsTest.java
@@ -7,24 +7,13 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 
-import javax.ws.rs.core.Response.Status;
-
 import org.folio.enums.SmtpEmail;
 import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.Configurations;
-import org.folio.rest.jaxrs.resource.Email;
 import org.folio.services.email.MailService;
 import org.junit.Test;
 
 public class EmailUtilsTest {
-
-  @Test
-  public void testMethodCreateResponse() {
-    String message = "test message";
-    verifyResponse(EmailUtils.createResponse(Status.OK, message), 200, message);
-    verifyResponse(EmailUtils.createResponse(Status.BAD_REQUEST, message), 400, message);
-    verifyResponse(EmailUtils.createResponse(Status.INTERNAL_SERVER_ERROR, message), 500, Status.INTERNAL_SERVER_ERROR.getReasonPhrase());
-  }
 
   @Test
   public void testMethodCheckMinConfigSmtpServer() {
@@ -32,11 +21,6 @@ public class EmailUtilsTest {
 
     boolean isIncorrectOrEmpty = EmailUtils.isIncorrectSmtpServerConfig(conf);
     assertTrue(isIncorrectOrEmpty);
-  }
-
-  private void verifyResponse(Email.PostEmailResponse response, int expectedStatusCode, String expectedMsg) {
-    assertEquals(expectedStatusCode, response.getStatus());
-    assertEquals(expectedMsg, response.getEntity());
   }
 
   @Test


### PR DESCRIPTION
**Purpose**
Getting all emails for metrics
Resolves: [MODEMAIL-21](https://issues.folio.org/browse/MODEMAIL-21)

**Approach**
1. Persist all emails in the database for some time (specified or default period on the basis of which will be carried out cleaning or archiving emails).
2. Handle SMTP server response status (delivered, failed, and other failures associated with an error within the module) and reasons for sending failure
3. Implement an endpoint to get processed emails (different interface)
