### PR TITLE
MODEMAIL-25 Endpoints w/o required permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -44,7 +44,7 @@
             "DELETE"
           ],
           "pathPattern": "/delayedTask/expiredMessages",
-          "modulePermissions": [
+          "permissionsRequired": [
             "email.message.delete"
           ]
         }


### PR DESCRIPTION
**Purpose**
Add `permissionsRequired` to the DELETE endpoint

Resolve: [MODEMAIL-25](https://issues.folio.org/browse/MODEMAIL-25)