### PR TITLE
MODEMAIL-36 update RMB and vertx versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>29.0.1</raml-module-builder.version>
-    <vertx.version>3.8.1</vertx.version>
+    <raml-module-builder.version>30.0.1</raml-module-builder.version>
+    <vertx.version>3.9.1</vertx.version>
     <subethasmtp.version>3.1.7</subethasmtp.version>
     <rest-assured.version>3.1.1</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>

--- a/src/main/java/org/folio/rest/impl/DelayedTasksAPI.java
+++ b/src/main/java/org/folio/rest/impl/DelayedTasksAPI.java
@@ -1,7 +1,5 @@
 package org.folio.rest.impl;
 
-import static javax.ws.rs.core.Response.Status;
-
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
@@ -31,6 +29,6 @@ public class DelayedTasksAPI extends AbstractEmail implements DelayedTask {
       .map(v -> DeleteDelayedTaskExpiredMessagesResponse.respond204())
       .map(Response.class::cast)
       .otherwise(this::mapExceptionToResponse)
-      .setHandler(resultHandler);
+      .onComplete(resultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/impl/EmailAPI.java
+++ b/src/main/java/org/folio/rest/impl/EmailAPI.java
@@ -31,7 +31,7 @@ public class EmailAPI extends AbstractEmail implements Email {
       .map(PostEmailResponse::respond200WithTextPlain)
       .map(Response.class::cast)
       .otherwise(this::mapExceptionToResponse)
-      .setHandler(resultHandler);
+      .onComplete(resultHandler);
   }
 
   @Override
@@ -43,6 +43,6 @@ public class EmailAPI extends AbstractEmail implements Email {
       .map(GetEmailResponse::respond200WithApplicationJson)
       .map(Response.class::cast)
       .otherwise(this::mapExceptionToResponse)
-      .setHandler(resultHandler);
+      .onComplete(resultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
+++ b/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
@@ -20,7 +20,6 @@ import java.util.regex.Pattern;
 
 import javax.ws.rs.core.Response;
 
-import io.vertx.core.Promise;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.exceptions.ConfigurationException;
 import org.folio.exceptions.SmtpConfigurationException;
@@ -32,6 +31,7 @@ import org.folio.services.storage.StorageService;
 
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpClient;
@@ -135,7 +135,7 @@ public abstract class AbstractEmail {
         .withDate(Timestamp.valueOf(LocalDateTime.now(ZoneOffset.UTC)))
         .withMessage(errorMessage));
 
-      saveEmail(emailEntityJson).setHandler(result -> {
+      saveEmail(emailEntityJson).onComplete(result -> {
         if (result.failed()) {
           logger.error(result.cause());
         }

--- a/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
+++ b/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
@@ -33,7 +33,6 @@ import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
@@ -96,7 +95,7 @@ public abstract class AbstractEmail {
 
   protected Future<JsonObject> lookupConfig(Map<String, String> requestHeaders) {
     Promise<JsonObject> promise = Promise.promise();
-    MultiMap headers = new CaseInsensitiveHeaders().addAll(requestHeaders);
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap().addAll(requestHeaders);
     String okapiUrl = headers.get(OKAPI_URL_HEADER);
     String okapiToken = headers.get(OKAPI_HEADER_TOKEN);
     String requestUrl = String.format(REQUEST_URL_TEMPLATE, okapiUrl, REQUEST_URI_PATH, MODULE_EMAIL_SMTP_SERVER);


### PR DESCRIPTION
## Approach

- Update to RMB v30.0.1
- Update vertx to 3.9.1
- Do all related changes according to RMB upgrading notes

Resolves: [MODEMAIL-36](https://issues.folio.org/browse/MODEMAIL-36)