### PR TITLE
MODEMAIL-43: Support both "http.port" and "port" property variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Module provides next API:
 
 See that it says "BUILD SUCCESS" near the end.
 
+## Port
+
+When running the jar file the module looks for the `http.port` and `port`
+system property variables in this order, and uses the default 8081 as fallback. Example:
+
+`java -Dhttp.port=8008 -jar target/mod-email-fat.jar`
+
+The Docker container exposes port 8081.
+
 ## Docker
 Build the docker container with:
 

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -28,7 +28,8 @@ public class InitAPIs implements InitAPI {
 
   @Override
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> handler) {
-    final int port = Integer.parseInt(System.getProperty("port", "8080"));
+    final int port = Integer.parseInt(
+      System.getProperty("http.port", System.getProperty("port", "8080")));
     logger.info(ManagementFactory.getRuntimeMXBean().getName() + " on port " + port);
     new ServiceBinder(vertx)
       .setAddress(MAIL_SERVICE_ADDRESS)


### PR DESCRIPTION
"http.port" is the command-line option name that most modules
support (the RMB based modules):
https://github.com/folio-org/raml-module-builder#command-line-options