### PR TITLE
MODEMAIL-61: No enum constant io.vertx.ext.mail.StartTLSOptions.NONE

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The module supports the following configuration for SMTP server:
  |  EMAIL_SMTP_LOGIN_OPTION |  the login mode for the connection     | DISABLED, OPTIONAL or REQUIRED |
  |  EMAIL_TRUST_ALL         |  trust all certificates on ssl connect | true or false                  |
  |  EMAIL_SMTP_SSL          |  sslOnConnect mode for the connection  | true or false                  |
- |  EMAIL_START_TLS_OPTIONS |  TLS security mode for the connection  | NONE, OPTIONAL or REQUIRED     |
+ |  EMAIL_START_TLS_OPTIONS |  TLS security mode for the connection  | DISABLED, OPTIONAL or REQUIRED |
  |  EMAIL_USERNAME          |  the username for the login            | 'login'                        |
  |  EMAIL_PASSWORD          |  the password for the login            | 'password'                     |
  |  EMAIL_FROM              |  'from' property of the email          | noreply@folio.org              |


### PR DESCRIPTION
Setting EMAIL_START_TLS_OPTIONS to NONE as suggested by
https://github.com/folio-org/mod-email/blob/v1.11.0/README.md#introduction
yields this error:

Error in the 'mod-email' module, the module didn't send email
message: No enum constant io.vertx.ext.mail.StartTLSOptions.NONE
11:34:44 [] [] [] [] ERROR AbstractEmail        No enum constant io.vertx.ext.mail.StartTLSOptions.NONE

https://vertx.io/docs/apidocs/io/vertx/ext/mail/StartTLSOptions.html uses DISABLED, not NONE.