### PR TITLE
MODEMAIL-66 Upgrade to RMB 33.0.4 and Log4j 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
+    <raml-module-builder.version>33.0.4</raml-module-builder.version>
     <vertx.version>4.1.0.CR1</vertx.version>
     <subethasmtp.version>3.1.7</subethasmtp.version>
     <rest-assured.version>4.3.0</rest-assured.version>


### PR DESCRIPTION
[MODEMAIL-66](https://issues.folio.org/browse/MODEMAIL-66)

Upgrade to RMB 33.0.4 which includes Log4j version with CVE-2021-44228 vulnerability fixed.