### PR TITLE
MODEMAIL-76 Move sensitive SMTP information out of mod-configuration

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -56,23 +56,28 @@
       "handlers": [
         {
           "methods": ["GET"],
-          "pathPattern": "/smtp-configuration",
-          "permissionsRequired": ["email.smtp-configuration.get"]
+          "pathPattern": "/smtp-configurations",
+          "permissionsRequired": ["email.smtp-configuration.collection.get"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/smtp-configurations/{smtpConfigurationId}",
+          "permissionsRequired": ["email.smtp-configuration.item.get"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/smtp-configuration",
-          "permissionsRequired": ["email.smtp-configuration.post"]
+          "permissionsRequired": ["email.smtp-configuration.item.post"]
         },
         {
           "methods": ["PUT"],
-          "pathPattern": "/smtp-configuration",
-          "permissionsRequired": ["email.smtp-configuration.put"]
+          "pathPattern": "/smtp-configuration/{smtpConfigurationId}",
+          "permissionsRequired": ["email.smtp-configuration.item.put"]
         },
         {
           "methods": ["DELETE"],
-          "pathPattern": "/smtp-configuration",
-          "permissionsRequired": ["email.smtp-configuration.delete"]
+          "pathPattern": "/smtp-configuration/{smtpConfigurationId}",
+          "permissionsRequired": ["email.smtp-configuration.item.delete"]
         }
       ]
     },
@@ -151,22 +156,27 @@
       "visible": false
     },
     {
-      "permissionName": "email.smtp-configuration.get",
+      "permissionName": "email.smtp-configuration.collection.get",
+      "displayName": "get SMTP configurations",
+      "description": "get configuration of the SMTP server"
+    },
+    {
+      "permissionName": "email.smtp-configuration.item.get",
       "displayName": "get SMTP configuration",
       "description": "get configuration of the SMTP server"
     },
     {
-      "permissionName": "email.smtp-configuration.post",
+      "permissionName": "email.smtp-configuration.item.post",
       "displayName": "create SMTP configuration",
       "description": "create configuration of the SMTP server"
     },
     {
-      "permissionName": "email.smtp-configuration.put",
+      "permissionName": "email.smtp-configuration.item.put",
       "displayName": "update SMTP configuration",
       "description": "update configuration of the SMTP server"
     },
     {
-      "permissionName": "email.smtp-configuration.delete",
+      "permissionName": "email.smtp-configuration.item.delete",
       "displayName": "delete SMTP configuration",
       "description": "delete configuration of the SMTP server"
     },
@@ -175,10 +185,11 @@
       "displayName": "SMTP configuration - all permissions",
       "description": "Entire set of permissions needed to manage SMTP configuration",
       "subPermissions": [
-        "email.smtp-configuration.get",
-        "email.smtp-configuration.post",
-        "email.smtp-configuration.put",
-        "email.smtp-configuration.delete"
+        "email.smtp-configuration.collection.get",
+        "email.smtp-configuration.item.get",
+        "email.smtp-configuration.item.post",
+        "email.smtp-configuration.item.put",
+        "email.smtp-configuration.item.delete"
       ],
       "visible": false
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -51,6 +51,32 @@
       ]
     },
     {
+      "id": "smtpConfiguration",
+      "version": "0.1",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/smtp-configuration",
+          "permissionsRequired": ["email.smtp-configuration.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/smtp-configuration",
+          "permissionsRequired": ["email.smtp-configuration.post"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/smtp-configuration",
+          "permissionsRequired": ["email.smtp-configuration.put"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/smtp-configuration",
+          "permissionsRequired": ["email.smtp-configuration.delete"]
+        }
+      ]
+    },
+    {
       "id": "_tenant",
       "version": "2.0",
       "interfaceType": "system",
@@ -121,6 +147,38 @@
         "email.message.post",
         "email.message.collection.get",
         "email.message.delete"
+      ],
+      "visible": false
+    },
+    {
+      "permissionName": "email.smtp-configuration.get",
+      "displayName": "get SMTP configuration",
+      "description": "get configuration of the SMTP server"
+    },
+    {
+      "permissionName": "email.smtp-configuration.post",
+      "displayName": "create SMTP configuration",
+      "description": "create configuration of the SMTP server"
+    },
+    {
+      "permissionName": "email.smtp-configuration.put",
+      "displayName": "update SMTP configuration",
+      "description": "update configuration of the SMTP server"
+    },
+    {
+      "permissionName": "email.smtp-configuration.delete",
+      "displayName": "delete SMTP configuration",
+      "description": "delete configuration of the SMTP server"
+    },
+    {
+      "permissionName": "email.smtp-configuration.all",
+      "displayName": "SMTP configuration - all permissions",
+      "description": "Entire set of permissions needed to manage SMTP configuration",
+      "subPermissions": [
+        "email.smtp-configuration.get",
+        "email.smtp-configuration.post",
+        "email.smtp-configuration.put",
+        "email.smtp-configuration.delete"
       ],
       "visible": false
     }

--- a/ramls/examples/smtp-configuration.sample
+++ b/ramls/examples/smtp-configuration.sample
@@ -1,0 +1,19 @@
+{
+  "id": "65de6432-be11-48ba-9686-a65101634040",
+  "host": "localhost",
+  "port": 502,
+  "username": "username",
+  "password": "password",
+  "ssl": true,
+  "trustAll": false,
+  "loginOption": "REQUIRED",
+  "startTlsOptions": "DISABLED",
+  "authMethods": "CRAM-MD5 LOGIN PLAIN",
+  "from": "noreply@folio.org",
+  "emailHeaders": [
+    {
+      "name": "Reply-To",
+      "value": "noreply@folio.org"
+    }
+  ]
+}

--- a/ramls/examples/smtp-configuration.sample
+++ b/ramls/examples/smtp-configuration.sample
@@ -1,19 +1,24 @@
 {
-  "id": "65de6432-be11-48ba-9686-a65101634040",
-  "host": "localhost",
-  "port": 502,
-  "username": "username",
-  "password": "password",
-  "ssl": true,
-  "trustAll": false,
-  "loginOption": "REQUIRED",
-  "startTlsOptions": "DISABLED",
-  "authMethods": "CRAM-MD5 LOGIN PLAIN",
-  "from": "noreply@folio.org",
-  "emailHeaders": [
+  "smtpConfigurations": [
     {
-      "name": "Reply-To",
-      "value": "noreply@folio.org"
+      "id": "65de6432-be11-48ba-9686-a65101634040",
+      "host": "localhost",
+      "port": 502,
+      "username": "username",
+      "password": "password",
+      "ssl": true,
+      "trustAll": false,
+      "loginOption": "REQUIRED",
+      "startTlsOptions": "DISABLED",
+      "authMethods": "CRAM-MD5 LOGIN PLAIN",
+      "from": "noreply@folio.org",
+      "emailHeaders": [
+        {
+          "name": "Reply-To",
+          "value": "noreply@folio.org"
+        }
+      ]
     }
-  ]
+  ],
+  "totalRecords": 1
 }

--- a/ramls/examples/smtp-configuration.sample
+++ b/ramls/examples/smtp-configuration.sample
@@ -1,24 +1,19 @@
 {
-  "smtpConfigurations": [
+  "id": "65de6432-be11-48ba-9686-a65101634040",
+  "host": "localhost",
+  "port": 502,
+  "username": "username",
+  "password": "password",
+  "ssl": true,
+  "trustAll": false,
+  "loginOption": "REQUIRED",
+  "startTlsOptions": "DISABLED",
+  "authMethods": "CRAM-MD5 LOGIN PLAIN",
+  "from": "noreply@folio.org",
+  "emailHeaders": [
     {
-      "id": "65de6432-be11-48ba-9686-a65101634040",
-      "host": "localhost",
-      "port": 502,
-      "username": "username",
-      "password": "password",
-      "ssl": true,
-      "trustAll": false,
-      "loginOption": "REQUIRED",
-      "startTlsOptions": "DISABLED",
-      "authMethods": "CRAM-MD5 LOGIN PLAIN",
-      "from": "noreply@folio.org",
-      "emailHeaders": [
-        {
-          "name": "Reply-To",
-          "value": "noreply@folio.org"
-        }
-      ]
+      "name": "Reply-To",
+      "value": "noreply@folio.org"
     }
-  ],
-  "totalRecords": 1
+  ]
 }

--- a/ramls/examples/smtp-configurations.sample
+++ b/ramls/examples/smtp-configurations.sample
@@ -1,0 +1,19 @@
+{
+  "id": "65de6432-be11-48ba-9686-a65101634040",
+  "host": "localhost",
+  "port": 502,
+  "username": "username",
+  "password": "password",
+  "ssl": true,
+  "trustAll": false,
+  "loginOption": "REQUIRED",
+  "startTlsOptions": "DISABLED",
+  "authMethods": "CRAM-MD5 LOGIN PLAIN",
+  "from": "noreply@folio.org",
+  "emailHeaders": [
+    {
+      "name": "Reply-To",
+      "value": "noreply@folio.org"
+    }
+  ]
+}

--- a/ramls/examples/smtp-configurations.sample
+++ b/ramls/examples/smtp-configurations.sample
@@ -1,19 +1,24 @@
 {
-  "id": "65de6432-be11-48ba-9686-a65101634040",
-  "host": "localhost",
-  "port": 502,
-  "username": "username",
-  "password": "password",
-  "ssl": true,
-  "trustAll": false,
-  "loginOption": "REQUIRED",
-  "startTlsOptions": "DISABLED",
-  "authMethods": "CRAM-MD5 LOGIN PLAIN",
-  "from": "noreply@folio.org",
-  "emailHeaders": [
+  "smtpConfigurations": [
     {
-      "name": "Reply-To",
-      "value": "noreply@folio.org"
+      "id": "65de6432-be11-48ba-9686-a65101634040",
+      "host": "localhost",
+      "port": 502,
+      "username": "username",
+      "password": "password",
+      "ssl": true,
+      "trustAll": false,
+      "loginOption": "REQUIRED",
+      "startTlsOptions": "DISABLED",
+      "authMethods": "CRAM-MD5 LOGIN PLAIN",
+      "from": "noreply@folio.org",
+      "emailHeaders": [
+        {
+          "name": "Reply-To",
+          "value": "noreply@folio.org"
+        }
+      ]
     }
-  ]
+  ],
+  "totalRecords": 1
 }

--- a/ramls/smtp-configuration.json
+++ b/ramls/smtp-configuration.json
@@ -37,8 +37,9 @@
       "type": "string",
       "enum": [
         "DISABLED",
-        "OPTIONAL",
-        "REQUIRED"
+        "NONE",
+        "REQUIRED",
+        "XOAUTH2"
       ]
     },
     "startTlsOptions": {

--- a/ramls/smtp-configuration.json
+++ b/ramls/smtp-configuration.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Configuration of the SMTP server",
+  "title": "SMTP configuration schema",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description":"Unique UUID of the email",
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
+    "host": {
+      "description": "SMTP server host",
+      "type": "string"
+    },
+    "port": {
+      "description": "SMTP server port",
+      "type": "integer"
+    },
+    "username": {
+      "description": "Username (credentials to access the SMTP server)",
+      "type": "string"
+    },
+    "password": {
+      "description": "Password (credentials to access the SMTP server)",
+      "type": "string"
+    },
+    "ssl": {
+      "description": "Connect to SMTP server using SSL",
+      "type": "boolean"
+    },
+    "trustAll": {
+      "description": "Trust all certificates when establishing an SSL connection",
+      "type": "boolean"
+    },
+    "loginOption": {
+      "description": "Login mode",
+      "type": "string",
+      "enum": [
+        "DISABLED",
+        "OPTIONAL",
+        "REQUIRED"
+      ]
+    },
+    "startTlsOptions": {
+      "description": "Start TLS options",
+      "type": "string",
+      "enum": [
+        "DISABLED",
+        "OPTIONAL",
+        "REQUIRED"
+      ]
+    },
+    "authMethods": {
+      "description": "Authentication methods",
+      "type": "string"
+    },
+    "from": {
+      "description": "Email address to send emails from",
+      "type": "string"
+    },
+    "emailHeaders": {
+      "description": "Custom email headers",
+      "type": "array",
+      "id": "emailHeaders",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Custom header name",
+            "type": "string"
+          },
+          "value": {
+            "description": "Custom header value",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "value"
+        ]
+      }
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes to the SMTP configuration provided by the server",
+      "type" : "object",
+      "$ref" : "raml-util/schemas/metadata.schema"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "host",
+    "port",
+    "username",
+    "password"
+  ]
+}

--- a/ramls/smtp-configuration.raml
+++ b/ramls/smtp-configuration.raml
@@ -1,0 +1,84 @@
+#%RAML 1.0
+
+title: SMTP server configuration
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost
+
+documentation:
+  - title: SMTP server configuration API
+    content: <b>API for managing SMTP server configuration</b>
+
+types:
+  errors: !include raml-util/schemas/errors.schema
+  smtp-configuration: !include smtp-configuration.json
+
+traits:
+  validate: !include raml-util/traits/validation.raml
+
+/smtp-configuration:
+  get:
+    description: Get SMTP configuration
+    responses:
+      200:
+        body:
+          application/json:
+            type: smtp-configuration
+            example: !include examples/smtp-configuration.sample
+      404:
+        description: "Not found"
+        body:
+          text/plain:
+            example: "Not found"
+      500:
+        description: "Internal server error"
+        body:
+          text/plain:
+            example: "Internal server error"
+  post:
+    is: [validate]
+    body:
+      application/json:
+        type: smtp-configuration
+    responses:
+      201:
+        description: "SMTP configuration has been created"
+        body:
+          application/json:
+            type: smtp-configuration
+      500:
+        description: "Internal server error"
+        body:
+          text/plain:
+            example: "Internal server error"
+  put:
+    is: [validate]
+    body:
+      application/json:
+        type: smtp-configuration
+    responses:
+      200:
+        description: "SMTP configuration has been updated"
+        body:
+          application/json:
+            type: smtp-configuration
+      404:
+        description: "Not found"
+        body:
+          text/plain:
+            example: "Not found"
+      500:
+        description: "Internal server error"
+        body:
+          text/plain:
+            example: "Internal server error"
+  delete:
+    description: "Delete Lost Item Fee Policy by id"
+    responses:
+      204:
+        description: "SMTP configuration has been deleted"
+      500:
+        description: "Internal server error"
+        body:
+          text/plain:
+            example: "Internal server error"

--- a/ramls/smtp-configuration.raml
+++ b/ramls/smtp-configuration.raml
@@ -10,75 +10,47 @@ documentation:
     content: <b>API for managing SMTP server configuration</b>
 
 types:
-  errors: !include raml-util/schemas/errors.schema
+  smtp-configurations: !include smtp-configurations.json
   smtp-configuration: !include smtp-configuration.json
+  errors: !include raml-util/schemas/errors.schema
+  parameters: !include raml-util/schemas/parameters.schema
 
 traits:
+  language: !include raml-util/traits/language.raml
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
   validate: !include raml-util/traits/validation.raml
 
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
+
 /smtp-configuration:
+  displayName: SMTP configurations
+  type:
+    collection:
+      exampleCollection: !include examples/smtp-configurations.sample
+      exampleItem: !include examples/smtp-configuration.sample
+      schemaCollection: smtp-configurations
+      schemaItem: smtp-configuration
   get:
-    description: Get SMTP configuration
-    responses:
-      200:
-        body:
-          application/json:
-            type: smtp-configuration
-            example: !include examples/smtp-configuration.sample
-      404:
-        description: "Not found"
-        body:
-          text/plain:
-            example: "Not found"
-      500:
-        description: "Internal server error"
-        body:
-          text/plain:
-            example: "Internal server error"
+    is: [pageable,
+         searchable: {description: "by using CQL", example: "ssl=true"}]
   post:
     is: [validate]
     body:
       application/json:
         type: smtp-configuration
-    responses:
-      201:
-        description: "SMTP configuration has been created"
-        body:
-          application/json:
-            type: smtp-configuration
-      500:
-        description: "Internal server error"
-        body:
-          text/plain:
-            example: "Internal server error"
-  put:
-    is: [validate]
-    body:
-      application/json:
-        type: smtp-configuration
-    responses:
-      200:
-        description: "SMTP configuration has been updated"
-        body:
-          application/json:
-            type: smtp-configuration
-      404:
-        description: "Not found"
-        body:
-          text/plain:
-            example: "Not found"
-      500:
-        description: "Internal server error"
-        body:
-          text/plain:
-            example: "Internal server error"
-  delete:
-    description: "Delete Lost Item Fee Policy by id"
-    responses:
-      204:
-        description: "SMTP configuration has been deleted"
-      500:
-        description: "Internal server error"
-        body:
-          text/plain:
-            example: "Internal server error"
+  /{smtpConfigurationId}:
+    type:
+      collection-item:
+        exampleItem: !include examples/smtp-configuration.sample
+        schema: smtp-configuration
+    get:
+      description: "Get SMTP configuration"
+    put:
+      description: "Update SMTP configuration"
+      is: [ validate ]
+    delete:
+      description: "Delete SMTP configuration"
+      is: [ language ]

--- a/ramls/smtp-configurations.json
+++ b/ramls/smtp-configurations.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Collection of SMTP configurations",
+  "type": "object",
+  "properties": {
+    "smtpConfigurations": {
+      "description": "List of SMTP configurations",
+      "id": "smtpConfigurations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "smtp-configuration.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "smtpConfigurations",
+    "totalRecords"
+  ]
+}

--- a/src/main/java/org/folio/exceptions/FailedToCreateRepositoryException.java
+++ b/src/main/java/org/folio/exceptions/FailedToCreateRepositoryException.java
@@ -1,0 +1,7 @@
+package org.folio.exceptions;
+
+public class FailedToCreateRepositoryException extends RuntimeException {
+  public FailedToCreateRepositoryException(Exception exception) {
+    super(exception);
+  }
+}

--- a/src/main/java/org/folio/exceptions/FailedToUpdateSmtpConfigurationException.java
+++ b/src/main/java/org/folio/exceptions/FailedToUpdateSmtpConfigurationException.java
@@ -1,7 +1,0 @@
-package org.folio.exceptions;
-
-public class FailedToUpdateSmtpConfigurationException extends SmtpConfigurationException {
-  public FailedToUpdateSmtpConfigurationException() {
-    super("Failed to update SMTP configuration");
-  }
-}

--- a/src/main/java/org/folio/exceptions/FailedToUpdateSmtpConfigurationException.java
+++ b/src/main/java/org/folio/exceptions/FailedToUpdateSmtpConfigurationException.java
@@ -1,0 +1,7 @@
+package org.folio.exceptions;
+
+public class FailedToUpdateSmtpConfigurationException extends SmtpConfigurationException {
+  public FailedToUpdateSmtpConfigurationException() {
+    super("Failed to update SMTP configuration");
+  }
+}

--- a/src/main/java/org/folio/exceptions/SmtpConfigurationNotFoundException.java
+++ b/src/main/java/org/folio/exceptions/SmtpConfigurationNotFoundException.java
@@ -1,6 +1,6 @@
 package org.folio.exceptions;
 
-public class SmtpConfigurationNotFoundException extends SmtpConfigurationException {
+public class SmtpConfigurationNotFoundException extends RuntimeException {
   public SmtpConfigurationNotFoundException() {
     super("SMTP configuration not found");
   }

--- a/src/main/java/org/folio/exceptions/SmtpConfigurationNotFoundException.java
+++ b/src/main/java/org/folio/exceptions/SmtpConfigurationNotFoundException.java
@@ -1,0 +1,7 @@
+package org.folio.exceptions;
+
+public class SmtpConfigurationNotFoundException extends SmtpConfigurationException {
+  public SmtpConfigurationNotFoundException() {
+    super("SMTP configuration not found");
+  }
+}

--- a/src/main/java/org/folio/repository/BaseRepository.java
+++ b/src/main/java/org/folio/repository/BaseRepository.java
@@ -1,18 +1,18 @@
 package org.folio.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.exceptions.FailedToCreateRepositoryException;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
-import org.folio.rest.tools.utils.ModuleName;
 import org.folio.rest.persist.interfaces.Results;
+import org.folio.rest.tools.utils.ModuleName;
 
 import io.vertx.core.Future;
 import io.vertx.sqlclient.RowSet;
@@ -35,7 +35,7 @@ public class BaseRepository<T> {
     try {
       this.cql2pgJson = new CQL2PgJSON(tableName + ".jsonb");
     } catch (FieldException e) {
-      throw new RuntimeException(e);
+      throw new FailedToCreateRepositoryException(e);
     }
   }
 

--- a/src/main/java/org/folio/repository/BaseRepository.java
+++ b/src/main/java/org/folio/repository/BaseRepository.java
@@ -50,9 +50,8 @@ public class BaseRepository<T> {
       .map(Results::getResults);
   }
 
-  public Future<Optional<T>> get(String id) {
-    return pgClient.getById(tableName, id, entityType)
-      .map(Optional::ofNullable);
+  public Future<T> get(String id) {
+    return pgClient.getById(tableName, id, entityType);
   }
 
   public Future<List<T>> getAllWithDefaultLimit() {

--- a/src/main/java/org/folio/repository/BaseRepository.java
+++ b/src/main/java/org/folio/repository/BaseRepository.java
@@ -1,0 +1,107 @@
+package org.folio.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.cql2pgjson.CQL2PgJSON;
+import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.rest.tools.utils.ModuleName;
+import org.folio.rest.persist.interfaces.Results;
+
+import io.vertx.core.Future;
+import io.vertx.sqlclient.RowSet;
+
+public class BaseRepository<T> {
+
+  private static final Logger log = LogManager.getLogger(BaseRepository.class);
+  private static final String OPERATION_EQUALS = "=";
+  private static final int DEFAULT_LIMIT = 100;
+
+  protected final PostgresClient pgClient;
+  protected final String tableName;
+  private final Class<T> entityType;
+  private final CQL2PgJSON cql2pgJson;
+
+  public BaseRepository(PostgresClient pgClient, String tableName, Class<T> entityType) {
+    this.pgClient = pgClient;
+    this.tableName = tableName;
+    this.entityType = entityType;
+    try {
+      this.cql2pgJson = new CQL2PgJSON(tableName + ".jsonb");
+    } catch (FieldException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public Future<List<T>> get(String query, int offset, int limit) {
+    CQLWrapper cql = new CQLWrapper(cql2pgJson, query, limit, offset);
+    return pgClient.get(tableName, entityType, cql, true)
+      .map(Results::getResults);
+  }
+
+  public Future<List<T>> get(Criterion criterion) {
+    return pgClient.get(tableName, entityType, criterion, true)
+      .map(Results::getResults);
+  }
+
+  public Future<Optional<T>> get(String id) {
+    return pgClient.getById(tableName, id, entityType)
+      .map(Optional::ofNullable);
+  }
+
+  public Future<List<T>> getAllWithDefaultLimit() {
+    return getAllWithLimit(DEFAULT_LIMIT);
+  }
+
+  public Future<List<T>> getAllWithLimit(int limit) {
+    return get(null, 0, limit);
+  }
+
+  public Future<String> save(T entity, String id) {
+    return pgClient.save(tableName, id, entity);
+  }
+
+  public Future<String> upsert(T entity, String id) {
+    return pgClient.upsert(tableName, id, entity);
+  }
+
+  public Future<Boolean> update(T entity, String id) {
+    return pgClient.update(tableName, entity, id)
+      .map(updateResult -> updateResult.rowCount() == 1);
+  }
+
+  public Future<Boolean> delete(String id) {
+    return pgClient.delete(tableName, id)
+      .map(updateResult -> updateResult.rowCount() == 1);
+  }
+
+  public Future<Boolean> delete(Criterion criterion) {
+    return pgClient.delete(tableName, criterion)
+      .map(RowSet::rowCount)
+      .onSuccess(rowCount -> log.info("Deleted {} record(s) from table {} using query: {}",
+        rowCount, tableName, criterion))
+      .map(rowCount -> rowCount > 0);
+  }
+
+  public Future<Void> removeAll(String tenantId) {
+    String deleteAllQuery = String.format("DELETE FROM %s_%s.%s", tenantId,
+      ModuleName.getModuleName(), tableName);
+    return pgClient.execute(deleteAllQuery).mapEmpty();
+  }
+
+  static Criterion buildCriterion(String key, String value) {
+    return new Criterion(new Criteria()
+      .addField(key)
+      .setOperation(OPERATION_EQUALS)
+      .setVal(value)
+      .setJSONB(true));
+  }
+
+}
+

--- a/src/main/java/org/folio/repository/SmtpConfigurationRepository.java
+++ b/src/main/java/org/folio/repository/SmtpConfigurationRepository.java
@@ -1,0 +1,12 @@
+package org.folio.repository;
+
+import org.folio.rest.jaxrs.model.SmtpConfiguration;
+import org.folio.rest.persist.PostgresClient;
+
+public class SmtpConfigurationRepository extends BaseRepository<SmtpConfiguration> {
+  public static final String SMTP_CONFIGURATION_TABLE_NAME = "smtp_configuration";
+
+  public SmtpConfigurationRepository(PostgresClient pgClient) {
+    super(pgClient, SMTP_CONFIGURATION_TABLE_NAME, SmtpConfiguration.class);
+  }
+}

--- a/src/main/java/org/folio/rest/client/OkapiClient.java
+++ b/src/main/java/org/folio/rest/client/OkapiClient.java
@@ -1,0 +1,54 @@
+package org.folio.rest.client;
+
+import static javax.ws.rs.core.HttpHeaders.ACCEPT;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+import static org.folio.okapi.common.XOkapiHeaders.TOKEN;
+import static org.folio.okapi.common.XOkapiHeaders.URL;
+import static org.folio.rest.client.WebClientProvider.getWebClient;
+
+import java.util.Map;
+
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+public class OkapiClient {
+  private final WebClient webClient;
+  private final String okapiUrl;
+  private final String tenant;
+  private final String token;
+
+  public OkapiClient(Vertx vertx, Map<String, String> okapiHeaders, WebClientOptions options) {
+    CaseInsensitiveMap<String, String> headers = new CaseInsensitiveMap<>(okapiHeaders);
+    this.webClient = getWebClient(vertx, options);
+    okapiUrl = headers.get(URL);
+    tenant = headers.get(TENANT);
+    token = headers.get(TOKEN);
+  }
+
+  public HttpRequest<Buffer> getAbs(String path) {
+    return webClient.requestAbs(HttpMethod.GET, okapiUrl + path)
+      .putHeader(ACCEPT, APPLICATION_JSON)
+      .putHeader(URL, okapiUrl)
+      .putHeader(TENANT, tenant)
+      .putHeader(TOKEN, token);
+  }
+
+  public HttpRequest<Buffer> deleteAbs(String path) {
+    return webClient.requestAbs(HttpMethod.DELETE, okapiUrl + path)
+      .putHeader(ACCEPT, APPLICATION_JSON)
+      .putHeader(URL, okapiUrl)
+      .putHeader(TENANT, tenant)
+      .putHeader(TOKEN, token);
+  }
+}

--- a/src/main/java/org/folio/rest/client/WebClientProvider.java
+++ b/src/main/java/org/folio/rest/client/WebClientProvider.java
@@ -1,0 +1,20 @@
+package org.folio.rest.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+public class WebClientProvider {
+  private static final Map<Vertx, WebClient> webClients = new HashMap<>();
+
+  private WebClientProvider() {
+  }
+
+  public static WebClient getWebClient(Vertx vertx, WebClientOptions options) {
+    return webClients.computeIfAbsent(vertx, v -> WebClient.create(v, options));
+  }
+
+}

--- a/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
+++ b/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
@@ -21,19 +21,19 @@ public class SmtpConfigurationApi implements org.folio.rest.jaxrs.resource.SmtpC
 
     new SmtpConfigurationService(okapiHeaders, vertxContext)
       .getSmtpConfiguration()
-      .onSuccess(config -> {
-        if (config == null) {
+      .onSuccess(config -> asyncResultHandler.handle(succeededFuture(
+        org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
+          .respond200WithApplicationJson(config))))
+      .onFailure(failure -> {
+        if (failure.getCause() instanceof SmtpConfigurationNotFoundException) {
           asyncResultHandler.handle(succeededFuture(
             org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
-              .respond404WithTextPlain("SMTP configuration not found")));
+              .respond404WithTextPlain(failure.getMessage())));
         }
         asyncResultHandler.handle(succeededFuture(
           org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
-            .respond200WithApplicationJson(config)));
-      })
-      .onFailure(failure -> asyncResultHandler.handle(succeededFuture(
-        org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
-          .respond500WithTextPlain(failure.getLocalizedMessage()))));
+            .respond500WithTextPlain(failure.getMessage())));
+      });
   }
 
   @Override

--- a/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
+++ b/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
@@ -29,6 +29,7 @@ public class SmtpConfigurationApi implements org.folio.rest.jaxrs.resource.SmtpC
           asyncResultHandler.handle(succeededFuture(
             org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
               .respond404WithTextPlain(failure.getMessage())));
+          return;
         }
         asyncResultHandler.handle(succeededFuture(
           org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
@@ -64,6 +65,7 @@ public class SmtpConfigurationApi implements org.folio.rest.jaxrs.resource.SmtpC
           asyncResultHandler.handle(succeededFuture(
             org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse
               .respond404WithTextPlain(failure.getMessage())));
+          return;
         }
         asyncResultHandler.handle(succeededFuture(
           org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse

--- a/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
+++ b/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
@@ -1,0 +1,89 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.exceptions.SmtpConfigurationNotFoundException;
+import org.folio.rest.jaxrs.model.SmtpConfiguration;
+import org.folio.services.SmtpConfigurationService;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+
+public class SmtpConfigurationApi implements org.folio.rest.jaxrs.resource.SmtpConfiguration {
+  @Override
+  public void getSmtpConfiguration(Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new SmtpConfigurationService(okapiHeaders, vertxContext)
+      .getSmtpConfiguration()
+      .onSuccess(config -> {
+        if (config == null) {
+          asyncResultHandler.handle(succeededFuture(
+            org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
+              .respond404WithTextPlain("SMTP configuration not found")));
+        }
+        asyncResultHandler.handle(succeededFuture(
+          org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
+            .respond200WithApplicationJson(config)));
+      })
+      .onFailure(failure -> asyncResultHandler.handle(succeededFuture(
+        org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
+          .respond500WithTextPlain(failure.getLocalizedMessage()))));
+  }
+
+  @Override
+  public void postSmtpConfiguration(SmtpConfiguration entity, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new SmtpConfigurationService(okapiHeaders, vertxContext)
+      .createSmtpConfiguration(entity)
+      .onSuccess(id -> asyncResultHandler.handle(succeededFuture(
+        org.folio.rest.jaxrs.resource.SmtpConfiguration.PostSmtpConfigurationResponse
+          .respond201WithApplicationJson(entity.withId(id)))))
+      .onFailure(failure -> asyncResultHandler.handle(succeededFuture(
+        org.folio.rest.jaxrs.resource.SmtpConfiguration.PostSmtpConfigurationResponse
+          .respond500WithTextPlain(failure.getMessage()))));
+  }
+
+  @Override
+  public void putSmtpConfiguration(SmtpConfiguration entity, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new SmtpConfigurationService(okapiHeaders, vertxContext)
+      .updateSmtpConfiguration(entity)
+      .onSuccess(updatedEntity -> asyncResultHandler.handle(succeededFuture(
+        org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse
+          .respond200WithApplicationJson(updatedEntity))))
+      .onFailure(failure -> {
+        if (failure.getCause() instanceof SmtpConfigurationNotFoundException) {
+          asyncResultHandler.handle(succeededFuture(
+            org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse
+              .respond404WithTextPlain(failure.getMessage())));
+        }
+        asyncResultHandler.handle(succeededFuture(
+          org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse
+            .respond500WithTextPlain(failure.getMessage())));
+      });
+  }
+
+  @Override
+  public void deleteSmtpConfiguration(Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new SmtpConfigurationService(okapiHeaders, vertxContext)
+      .deleteSmtpConfiguration()
+      .onSuccess(v -> asyncResultHandler.handle(succeededFuture(
+        org.folio.rest.jaxrs.resource.SmtpConfiguration.DeleteSmtpConfigurationResponse
+          .respond204())))
+      .onFailure(failure -> {
+        asyncResultHandler.handle(succeededFuture(
+          org.folio.rest.jaxrs.resource.SmtpConfiguration.DeleteSmtpConfigurationResponse
+            .respond500WithTextPlain(failure.getLocalizedMessage())));
+      });
+  }
+}

--- a/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
+++ b/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
@@ -25,7 +25,7 @@ public class SmtpConfigurationApi implements org.folio.rest.jaxrs.resource.SmtpC
         org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
           .respond200WithApplicationJson(config))))
       .onFailure(failure -> {
-        if (failure.getCause() instanceof SmtpConfigurationNotFoundException) {
+        if (failure instanceof SmtpConfigurationNotFoundException) {
           asyncResultHandler.handle(succeededFuture(
             org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
               .respond404WithTextPlain(failure.getMessage())));
@@ -60,7 +60,7 @@ public class SmtpConfigurationApi implements org.folio.rest.jaxrs.resource.SmtpC
         org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse
           .respond200WithApplicationJson(updatedEntity))))
       .onFailure(failure -> {
-        if (failure.getCause() instanceof SmtpConfigurationNotFoundException) {
+        if (failure instanceof SmtpConfigurationNotFoundException) {
           asyncResultHandler.handle(succeededFuture(
             org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse
               .respond404WithTextPlain(failure.getMessage())));

--- a/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
+++ b/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
@@ -42,9 +42,9 @@ public class SmtpConfigurationApi implements org.folio.rest.jaxrs.resource.SmtpC
 
     new SmtpConfigurationService(okapiHeaders, vertxContext)
       .createSmtpConfiguration(entity)
-      .onSuccess(id -> asyncResultHandler.handle(succeededFuture(
+      .onSuccess(createdEntity -> asyncResultHandler.handle(succeededFuture(
         org.folio.rest.jaxrs.resource.SmtpConfiguration.PostSmtpConfigurationResponse
-          .respond201WithApplicationJson(entity.withId(id)))))
+          .respond201WithApplicationJson(createdEntity))))
       .onFailure(failure -> asyncResultHandler.handle(succeededFuture(
         org.folio.rest.jaxrs.resource.SmtpConfiguration.PostSmtpConfigurationResponse
           .respond500WithTextPlain(failure.getMessage()))));

--- a/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
+++ b/src/main/java/org/folio/rest/impl/SmtpConfigurationApi.java
@@ -1,91 +1,67 @@
 package org.folio.rest.impl;
 
-import static io.vertx.core.Future.succeededFuture;
-
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
-import org.folio.exceptions.SmtpConfigurationNotFoundException;
 import org.folio.rest.jaxrs.model.SmtpConfiguration;
-import org.folio.services.SmtpConfigurationService;
+import org.folio.rest.jaxrs.model.SmtpConfigurations;
+import org.folio.rest.persist.PgUtil;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 
 public class SmtpConfigurationApi implements org.folio.rest.jaxrs.resource.SmtpConfiguration {
-  @Override
-  public void getSmtpConfiguration(Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public static final String SMTP_CONFIGURATION_TABLE_NAME = "smtp_configuration";
 
-    new SmtpConfigurationService(okapiHeaders, vertxContext)
-      .getSmtpConfiguration()
-      .onSuccess(config -> asyncResultHandler.handle(succeededFuture(
-        org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
-          .respond200WithApplicationJson(config))))
-      .onFailure(failure -> {
-        if (failure instanceof SmtpConfigurationNotFoundException) {
-          asyncResultHandler.handle(succeededFuture(
-            org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
-              .respond404WithTextPlain(failure.getMessage())));
-          return;
-        }
-        asyncResultHandler.handle(succeededFuture(
-          org.folio.rest.jaxrs.resource.SmtpConfiguration.GetSmtpConfigurationResponse
-            .respond500WithTextPlain(failure.getMessage())));
-      });
+  @Override
+  public void getSmtpConfiguration(int offset, int limit, String query, String lang,
+    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
+
+    PgUtil.get(SMTP_CONFIGURATION_TABLE_NAME, SmtpConfiguration.class, SmtpConfigurations.class,
+      query, offset, limit, okapiHeaders, vertxContext, GetSmtpConfigurationResponse.class)
+      .onComplete(asyncResultHandler);
   }
 
   @Override
-  public void postSmtpConfiguration(SmtpConfiguration entity, Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void postSmtpConfiguration(String lang, SmtpConfiguration entity,
+    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
 
-    new SmtpConfigurationService(okapiHeaders, vertxContext)
-      .createSmtpConfiguration(entity)
-      .onSuccess(createdEntity -> asyncResultHandler.handle(succeededFuture(
-        org.folio.rest.jaxrs.resource.SmtpConfiguration.PostSmtpConfigurationResponse
-          .respond201WithApplicationJson(createdEntity))))
-      .onFailure(failure -> asyncResultHandler.handle(succeededFuture(
-        org.folio.rest.jaxrs.resource.SmtpConfiguration.PostSmtpConfigurationResponse
-          .respond500WithTextPlain(failure.getMessage()))));
+    PgUtil.post(SMTP_CONFIGURATION_TABLE_NAME, entity, okapiHeaders, vertxContext,
+      PostSmtpConfigurationResponse.class)
+      .onComplete(asyncResultHandler);
   }
 
   @Override
-  public void putSmtpConfiguration(SmtpConfiguration entity, Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getSmtpConfigurationBySmtpConfigurationId(String smtpConfigurationId, String lang,
+    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
 
-    new SmtpConfigurationService(okapiHeaders, vertxContext)
-      .updateSmtpConfiguration(entity)
-      .onSuccess(updatedEntity -> asyncResultHandler.handle(succeededFuture(
-        org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse
-          .respond200WithApplicationJson(updatedEntity))))
-      .onFailure(failure -> {
-        if (failure instanceof SmtpConfigurationNotFoundException) {
-          asyncResultHandler.handle(succeededFuture(
-            org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse
-              .respond404WithTextPlain(failure.getMessage())));
-          return;
-        }
-        asyncResultHandler.handle(succeededFuture(
-          org.folio.rest.jaxrs.resource.SmtpConfiguration.PutSmtpConfigurationResponse
-            .respond500WithTextPlain(failure.getMessage())));
-      });
+    PgUtil.getById(SMTP_CONFIGURATION_TABLE_NAME, SmtpConfiguration.class,
+      smtpConfigurationId, okapiHeaders, vertxContext,
+      GetSmtpConfigurationBySmtpConfigurationIdResponse.class).onComplete(asyncResultHandler);
   }
 
   @Override
-  public void deleteSmtpConfiguration(Map<String, String> okapiHeaders,
+  public void putSmtpConfigurationBySmtpConfigurationId(String smtpConfigurationId, String lang,
+    SmtpConfiguration entity, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    new SmtpConfigurationService(okapiHeaders, vertxContext)
-      .deleteSmtpConfiguration()
-      .onSuccess(v -> asyncResultHandler.handle(succeededFuture(
-        org.folio.rest.jaxrs.resource.SmtpConfiguration.DeleteSmtpConfigurationResponse
-          .respond204())))
-      .onFailure(failure -> {
-        asyncResultHandler.handle(succeededFuture(
-          org.folio.rest.jaxrs.resource.SmtpConfiguration.DeleteSmtpConfigurationResponse
-            .respond500WithTextPlain(failure.getLocalizedMessage())));
-      });
+    PgUtil.put(SMTP_CONFIGURATION_TABLE_NAME, entity, smtpConfigurationId, okapiHeaders,
+      vertxContext, PutSmtpConfigurationBySmtpConfigurationIdResponse.class)
+      .onComplete(asyncResultHandler);
+  }
+
+  @Override
+  public void deleteSmtpConfigurationBySmtpConfigurationId(String smtpConfigurationId, String lang,
+    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
+
+    PgUtil.deleteById(SMTP_CONFIGURATION_TABLE_NAME, smtpConfigurationId, okapiHeaders,
+      vertxContext, DeleteSmtpConfigurationBySmtpConfigurationIdResponse.class)
+      .onComplete(asyncResultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
+++ b/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
@@ -7,15 +7,11 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
-import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.HttpStatus.HTTP_NO_CONTENT;
 import static org.folio.HttpStatus.HTTP_OK;
 import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 import static org.folio.rest.jaxrs.model.EmailEntity.Status.DELIVERED;
 import static org.folio.rest.jaxrs.model.EmailEntity.Status.FAILURE;
 import static org.folio.util.AsyncUtil.mapInOrder;
@@ -25,7 +21,6 @@ import static org.folio.util.EmailUtils.findStatusByName;
 
 import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -37,6 +32,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.exceptions.ConfigurationException;
 import org.folio.exceptions.SmtpConfigurationException;
+import org.folio.rest.client.OkapiClient;
 import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.EmailEntity;
@@ -51,49 +47,47 @@ import org.folio.util.EmailUtils;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 public abstract class AbstractEmail {
 
-  private static final String REQUEST_URL_TEMPLATE = "%s/%s?query=module==%s";
-  private static final String REQUEST_URI_PATH = "configurations/entries";
-  private static final String DELETE_CONFIG_URI_PATH = "%s/configurations/entries/%s";
-  private static final String OKAPI_URL_HEADER = "x-okapi-url";
+  private static final String GET_CONFIG_PATH = "/configurations/entries?query=module==%s";
+  private static final String DELETE_CONFIG_PATH = "/configurations/entries/%s";
   private static final String MODULE_EMAIL_SMTP_SERVER = "SMTP_SERVER";
   private static final String LOOKUP_TIMEOUT = "lookup.timeout";
   private static final String LOOKUP_TIMEOUT_VAL = "1000";
   public static final int RETRY_MAX_ATTEMPTS = 3;
 
   private static final Pattern DATE_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}$");
-  private static final String ERROR_LOOKING_UP_MOD_CONFIG = "Error looking up config at url=%s | Expected status code 200, got %s | error message: %s";
+  private static final String ERROR_LOOKING_UP_MOD_CONFIG = "Error looking up config at %s | Expected status code 200, got %s | error message: %s";
   private static final String ERROR_MESSAGE_INCORRECT_DATE_PARAMETER = "Invalid date value, the parameter must be in the format: yyyy-MM-dd";
   private static final String ERROR_SENDING_EMAIL = "Error in the 'mod-email' module, the module didn't send email | message: %s";
   private static final String SUCCESS_SEND_EMAIL = "The message has been delivered to %s";
 
   protected static final Logger logger = LogManager.getLogger(AbstractEmail.class);
   protected final Vertx vertx;
-  private String tenantId;
+  private final String tenantId;
+  private final WebClientOptions webClientOptions;
 
-  private WebClient httpClient;
   private MailService mailService;
   private StorageService storageService;
   private SmtpConfigurationService smtpConfigurationService;
 
-  /**
-   * Timeout to wait for response
-   */
-  private final int lookupTimeout = Integer.parseInt(
-    MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, LOOKUP_TIMEOUT_VAL));
 
   public AbstractEmail(Vertx vertx, String tenantId) {
     this.vertx = vertx;
     this.tenantId = tenantId;
-    initHttpClient();
+
+    final int lookupTimeout = Integer.parseInt(
+      MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, LOOKUP_TIMEOUT_VAL));
+
+    this.webClientOptions = new WebClientOptions();
+    this.webClientOptions.setConnectTimeout(lookupTimeout);
+    this.webClientOptions.setIdleTimeout(lookupTimeout);
+
     initServices();
   }
 
@@ -104,16 +98,6 @@ public abstract class AbstractEmail {
     mailService = MailService.createProxy(vertx, MAIL_SERVICE_ADDRESS);
     storageService = StorageService.createProxy(vertx, STORAGE_SERVICE_ADDRESS);
     smtpConfigurationService = new SmtpConfigurationService(vertx, tenantId);
-  }
-
-  /**
-   * init the http client to 'mod-config'
-   */
-  private void initHttpClient() {
-    WebClientOptions options = new WebClientOptions();
-    options.setConnectTimeout(lookupTimeout);
-    options.setIdleTimeout(lookupTimeout);
-    this.httpClient = WebClient.create(vertx, options);
   }
 
   protected Future<EmailEntity> processEmail(EmailEntity email,
@@ -190,66 +174,23 @@ public abstract class AbstractEmail {
   private Future<SmtpConfiguration> lookupSmtpConfiguration(Map<String, String> requestHeaders) {
     return smtpConfigurationService.getSmtpConfiguration()
       .compose(EmailUtils::validateSmtpConfiguration)
-      .recover(throwable -> fetchSmtpConfigurationFromModConfig(requestHeaders)
-        .compose(configs -> copyConfigToDbAndRemoveFromModConfig(configs, requestHeaders)));
+      .recover(throwable -> moveConfigsFromModConfigurationToLocalDb(requestHeaders));
   }
 
-  private Future<SmtpConfiguration> copyConfigToDbAndRemoveFromModConfig(
-    Configurations configurations, Map<String, String> requestHeaders) {
-
-    return succeededFuture(configurations)
-      .map(EmailUtils::convertSmtpConfiguration)
-      .compose(EmailUtils::validateSmtpConfiguration)
-      .compose(smtpConfigurationService::createSmtpConfiguration)
-      .compose(smtpConfigurationId -> smtpConfigurationService.getSmtpConfiguration())
-      .compose(EmailUtils::validateSmtpConfiguration)
-      .compose(smtpConfig -> removeEntriesFromModConfig(smtpConfig, configurations, requestHeaders));
-  }
-
-  private Future<SmtpConfiguration> removeEntriesFromModConfig(
-    SmtpConfiguration validSmtpConfiguration, Configurations configurationsToDelete,
+  private Future<SmtpConfiguration> moveConfigsFromModConfigurationToLocalDb(
     Map<String, String> requestHeaders) {
 
-    logger.warn("Removing configuration from mod-config");
-
-    return CompositeFuture.all(configurationsToDelete.getConfigs().stream()
-        .map(Config::getId)
-        .map(id -> {
-          MultiMap headers = MultiMap.caseInsensitiveMultiMap().addAll(requestHeaders);
-          String okapiUrl = headers.get(OKAPI_URL_HEADER);
-          String okapiToken = headers.get(OKAPI_HEADER_TOKEN);
-          String url = String.format(DELETE_CONFIG_URI_PATH, okapiUrl, id);
-
-          return httpClient.deleteAbs(url)
-            .putHeader(OKAPI_HEADER_TOKEN, okapiToken)
-            .putHeader(OKAPI_HEADER_TENANT, tenantId)
-            .send()
-            .compose(response -> {
-              if (response.statusCode() == HTTP_NO_CONTENT.toInt()) {
-                logger.info("Successfully deleted configuration entry {}", id);
-              }
-              String errorMessage = format("Failed to delete configuration entry %s", id);
-              logger.error(errorMessage);
-              return failedFuture(new ConfigurationException(errorMessage));
-            });
-        })
-        .collect(Collectors.toList()))
-      .map(validSmtpConfiguration);
+    return fetchSmtpConfigurationFromModConfig(requestHeaders)
+      .compose(configs -> copyConfigurationAndDeleteFromModConfig(configs, requestHeaders));
   }
 
   private Future<Configurations> fetchSmtpConfigurationFromModConfig(Map<String, String> requestHeaders) {
     logger.warn("Failed to find SMTP configuration in the DB, fetching from mod-config");
 
-    MultiMap headers = MultiMap.caseInsensitiveMultiMap().addAll(requestHeaders);
-    String okapiUrl = headers.get(OKAPI_URL_HEADER);
-    String okapiToken = headers.get(OKAPI_HEADER_TOKEN);
-    String url = String.format(REQUEST_URL_TEMPLATE, okapiUrl, REQUEST_URI_PATH, MODULE_EMAIL_SMTP_SERVER);
+    OkapiClient okapiClient = new OkapiClient(vertx, requestHeaders, webClientOptions);
+    String path = format(GET_CONFIG_PATH, MODULE_EMAIL_SMTP_SERVER);
 
-    return httpClient.getAbs(url)
-      .putHeader(OKAPI_HEADER_TOKEN, okapiToken)
-      .putHeader(OKAPI_HEADER_TENANT, tenantId)
-      .putHeader(CONTENT_TYPE, APPLICATION_JSON)
-      .putHeader(ACCEPT, APPLICATION_JSON)
+    return okapiClient.getAbs(path)
       .send()
       .compose(response -> {
         if (response.statusCode() == HTTP_OK.toInt()) {
@@ -258,10 +199,49 @@ public abstract class AbstractEmail {
           return succeededFuture(config);
         }
         String errorMessage = String.format(ERROR_LOOKING_UP_MOD_CONFIG,
-          url, response.statusCode(), response.bodyAsString());
+          path, response.statusCode(), response.bodyAsString());
         logger.error(errorMessage);
         return failedFuture(new ConfigurationException(errorMessage));
       });
+  }
+
+  private Future<SmtpConfiguration> copyConfigurationAndDeleteFromModConfig(
+    Configurations configurations, Map<String, String> requestHeaders) {
+
+    return succeededFuture(configurations)
+      .map(EmailUtils::convertSmtpConfiguration)
+      .compose(EmailUtils::validateSmtpConfiguration)
+      .compose(smtpConfigurationService::createSmtpConfiguration)
+      .compose(smtpConfig -> deleteEntriesFromModConfig(smtpConfig, configurations, requestHeaders));
+  }
+
+  private Future<SmtpConfiguration> deleteEntriesFromModConfig(
+    SmtpConfiguration validSmtpConfiguration, Configurations configurationsToDelete,
+    Map<String, String> requestHeaders) {
+
+    logger.warn("Removing configuration from mod-config");
+
+    OkapiClient okapiClient = new OkapiClient(vertx, requestHeaders, webClientOptions);
+
+    return CompositeFuture.all(configurationsToDelete.getConfigs().stream()
+        .map(Config::getId)
+        .map(id -> {
+          String path = format(DELETE_CONFIG_PATH, id);
+
+          return okapiClient.deleteAbs(path)
+            .send()
+            .compose(response -> {
+              if (response.statusCode() == HTTP_NO_CONTENT.toInt()) {
+                logger.info("Successfully deleted configuration entry {}", id);
+                return succeededFuture();
+              }
+              String errorMessage = format("Failed to delete configuration entry %s", id);
+              logger.error(errorMessage);
+              return failedFuture(new ConfigurationException(errorMessage));
+            });
+        })
+        .collect(Collectors.toList()))
+      .map(validSmtpConfiguration);
   }
 
   protected Future<EmailEntity> sendEmail(EmailEntity email, SmtpConfiguration smtpConfiguration) {

--- a/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
+++ b/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
@@ -183,8 +183,7 @@ public abstract class AbstractEmail {
     OkapiClient okapiClient = new OkapiClient(vertx, requestHeaders, webClientOptions);
 
     return fetchSmtpConfigurationFromModConfig(okapiClient)
-      .compose(configs -> copyConfigurationAndDeleteFromModConfig(configs, requestHeaders,
-        okapiClient));
+      .compose(configs -> copyConfigurationAndDeleteFromModConfig(configs, okapiClient));
   }
 
   private Future<Configurations> fetchSmtpConfigurationFromModConfig(OkapiClient okapiClient) {
@@ -208,7 +207,7 @@ public abstract class AbstractEmail {
   }
 
   private Future<SmtpConfiguration> copyConfigurationAndDeleteFromModConfig(
-    Configurations configurations, Map<String, String> requestHeaders, OkapiClient okapiClient) {
+    Configurations configurations, OkapiClient okapiClient) {
 
     return succeededFuture(configurations)
       .map(EmailUtils::convertSmtpConfiguration)

--- a/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
+++ b/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
@@ -54,8 +54,9 @@ import io.vertx.ext.web.client.WebClientOptions;
 
 public abstract class AbstractEmail {
 
-  private static final String GET_CONFIG_PATH = "/configurations/entries?query=module==%s";
-  private static final String DELETE_CONFIG_PATH = "/configurations/entries/%s";
+  private static final String CONFIG_BASE_PATH = "/configurations/entries";
+  private static final String GET_CONFIG_PATH_TEMPLATE = "%s?query=module==%s";
+  private static final String DELETE_CONFIG_PATH_TEMPLATE = "%s/%s";
   private static final String MODULE_EMAIL_SMTP_SERVER = "SMTP_SERVER";
   private static final String LOOKUP_TIMEOUT = "lookup.timeout";
   private static final String LOOKUP_TIMEOUT_VAL = "1000";
@@ -188,7 +189,7 @@ public abstract class AbstractEmail {
     logger.warn("Failed to find SMTP configuration in the DB, fetching from mod-config");
 
     OkapiClient okapiClient = new OkapiClient(vertx, requestHeaders, webClientOptions);
-    String path = format(GET_CONFIG_PATH, MODULE_EMAIL_SMTP_SERVER);
+    String path = format(GET_CONFIG_PATH_TEMPLATE, CONFIG_BASE_PATH, MODULE_EMAIL_SMTP_SERVER);
 
     return okapiClient.getAbs(path)
       .send()
@@ -226,7 +227,7 @@ public abstract class AbstractEmail {
     return CompositeFuture.all(configurationsToDelete.getConfigs().stream()
         .map(Config::getId)
         .map(id -> {
-          String path = format(DELETE_CONFIG_PATH, id);
+          String path = format(DELETE_CONFIG_PATH_TEMPLATE, CONFIG_BASE_PATH, id);
 
           return okapiClient.deleteAbs(path)
             .send()

--- a/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
+++ b/src/main/java/org/folio/rest/impl/base/AbstractEmail.java
@@ -228,15 +228,14 @@ public abstract class AbstractEmail {
 
         okapiClient.deleteAbs(path)
           .send()
-          .compose(response -> {
+          .onSuccess(response -> {
             if (response.statusCode() == HTTP_NO_CONTENT.toInt()) {
               logger.info("Successfully deleted configuration entry {}", id);
-              return succeededFuture();
+              return;
             }
-            String errorMessage = format("Failed to delete configuration entry %s", id);
-            logger.error(errorMessage);
-            return failedFuture(new ConfigurationException(errorMessage));
-          });
+            logger.error(format("Failed to delete configuration entry %s", id));
+          })
+          .onFailure(logger::error);
       });
   }
 

--- a/src/main/java/org/folio/services/SmtpConfigurationService.java
+++ b/src/main/java/org/folio/services/SmtpConfigurationService.java
@@ -21,7 +21,7 @@ public class SmtpConfigurationService {
 
   public Future<SmtpConfiguration> getSmtpConfiguration() {
     return repository.getAllWithLimit(1)
-      .compose(configs -> configs.size() < 1
+      .compose(configs -> configs.isEmpty()
         ? failedFuture(new SmtpConfigurationNotFoundException())
         : succeededFuture(configs.get(0)));
   }

--- a/src/main/java/org/folio/services/SmtpConfigurationService.java
+++ b/src/main/java/org/folio/services/SmtpConfigurationService.java
@@ -39,6 +39,13 @@ public class SmtpConfigurationService {
         : succeededFuture(configs.get(0)));
   }
 
+  public Future<SmtpConfiguration> getSmtpConfigurationById(String id) {
+    return repository.get(id)
+      .compose(config -> config == null
+        ? failedFuture(new SmtpConfigurationNotFoundException())
+        : succeededFuture(config));
+  }
+
   public Future<SmtpConfiguration> createSmtpConfiguration(SmtpConfiguration smtpConfiguration) {
     String proposedId = smtpConfiguration.getId() == null
       ? UUID.randomUUID().toString()
@@ -50,7 +57,11 @@ public class SmtpConfigurationService {
   }
 
   public Future<SmtpConfiguration> updateSmtpConfiguration(SmtpConfiguration smtpConfiguration) {
-    return getSmtpConfiguration()
+    Future<SmtpConfiguration> smtpConfigurationFuture = smtpConfiguration.getId() == null
+      ? getSmtpConfiguration()
+      : getSmtpConfigurationById(smtpConfiguration.getId());
+
+    return smtpConfigurationFuture
       .compose(config -> repository.update(smtpConfiguration, config.getId()))
       .compose(updateSucceeded -> updateSucceeded
         ? succeededFuture(smtpConfiguration)

--- a/src/main/java/org/folio/services/SmtpConfigurationService.java
+++ b/src/main/java/org/folio/services/SmtpConfigurationService.java
@@ -1,0 +1,59 @@
+package org.folio.services;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.UUID.randomUUID;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+
+import java.util.Map;
+
+import org.folio.exceptions.FailedToUpdateSmtpConfigurationException;
+import org.folio.exceptions.SmtpConfigurationNotFoundException;
+import org.folio.repository.SmtpConfigurationRepository;
+import org.folio.rest.jaxrs.model.SmtpConfiguration;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.TenantTool;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+
+public class SmtpConfigurationService {
+  private final Map<String, String> okapiHeaders;
+  private final SmtpConfigurationRepository repository;
+  public SmtpConfigurationService(Map<String, String> okapiHeaders, Context vertxContext) {
+    this.okapiHeaders = okapiHeaders;
+    PostgresClient pgClient = PostgresClient.getInstance(vertxContext.owner(),
+      tenantId(okapiHeaders));
+    repository = new SmtpConfigurationRepository(pgClient);
+  }
+
+  public Future<SmtpConfiguration> getSmtpConfiguration() {
+    return repository.getAllWithLimit(1)
+      .map(configs -> configs.stream().findFirst().orElse(null));
+  }
+
+  public Future<String> createSmtpConfiguration(SmtpConfiguration smtpConfiguration) {
+    return getSmtpConfigurationId()
+      .compose(id -> repository.save(smtpConfiguration, id));
+  }
+
+  public Future<SmtpConfiguration> updateSmtpConfiguration(SmtpConfiguration smtpConfiguration) {
+    return getSmtpConfiguration()
+      .compose(config -> config == null
+        ? Future.failedFuture(new SmtpConfigurationNotFoundException())
+        : succeededFuture(config))
+      .compose(config -> repository.update(config, config.getId()))
+      .compose(updateSucceeded -> updateSucceeded
+        ? getSmtpConfiguration()
+        : failedFuture(new FailedToUpdateSmtpConfigurationException()));
+  }
+
+  public Future<Void> deleteSmtpConfiguration() {
+    return repository.removeAll(TenantTool.tenantId(okapiHeaders));
+  }
+
+  private Future<String> getSmtpConfigurationId() {
+    return getSmtpConfiguration()
+      .map(config -> config == null ? randomUUID().toString() : config.getId());
+  }
+}

--- a/src/main/java/org/folio/services/SmtpConfigurationService.java
+++ b/src/main/java/org/folio/services/SmtpConfigurationService.java
@@ -2,34 +2,21 @@ package org.folio.services;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
-import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
-import java.util.Map;
-import java.util.UUID;
-
-import org.folio.exceptions.FailedToUpdateSmtpConfigurationException;
 import org.folio.exceptions.SmtpConfigurationNotFoundException;
 import org.folio.repository.SmtpConfigurationRepository;
 import org.folio.rest.jaxrs.model.SmtpConfiguration;
 import org.folio.rest.persist.PostgresClient;
 
-import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 public class SmtpConfigurationService {
-  private final String tenantId;
   private final SmtpConfigurationRepository repository;
 
   public SmtpConfigurationService(Vertx vertx, String tenantId) {
-    this.tenantId = tenantId;
-
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
     repository = new SmtpConfigurationRepository(pgClient);
-  }
-
-  public SmtpConfigurationService(Map<String, String> okapiHeaders, Context vertxContext) {
-    this(vertxContext.owner(), tenantId(okapiHeaders));
   }
 
   public Future<SmtpConfiguration> getSmtpConfiguration() {
@@ -39,42 +26,8 @@ public class SmtpConfigurationService {
         : succeededFuture(configs.get(0)));
   }
 
-  public Future<SmtpConfiguration> getSmtpConfigurationById(String id) {
-    return repository.get(id)
-      .compose(config -> config == null
-        ? failedFuture(new SmtpConfigurationNotFoundException())
-        : succeededFuture(config));
-  }
-
   public Future<SmtpConfiguration> createSmtpConfiguration(SmtpConfiguration smtpConfiguration) {
-    String proposedId = smtpConfiguration.getId() == null
-      ? UUID.randomUUID().toString()
-      : smtpConfiguration.getId();
-
-    return getSmtpConfigurationId(proposedId)
-      .compose(id -> repository.save(smtpConfiguration, id))
+    return repository.save(smtpConfiguration, smtpConfiguration.getId())
       .map(smtpConfiguration::withId);
-  }
-
-  public Future<SmtpConfiguration> updateSmtpConfiguration(SmtpConfiguration smtpConfiguration) {
-    Future<SmtpConfiguration> smtpConfigurationFuture = smtpConfiguration.getId() == null
-      ? getSmtpConfiguration()
-      : getSmtpConfigurationById(smtpConfiguration.getId());
-
-    return smtpConfigurationFuture
-      .compose(config -> repository.update(smtpConfiguration, config.getId()))
-      .compose(updateSucceeded -> updateSucceeded
-        ? succeededFuture(smtpConfiguration)
-        : failedFuture(new FailedToUpdateSmtpConfigurationException()));
-  }
-
-  public Future<Void> deleteSmtpConfiguration() {
-    return repository.removeAll(tenantId);
-  }
-
-  private Future<String> getSmtpConfigurationId(String proposedId) {
-    return getSmtpConfiguration()
-      .map(SmtpConfiguration::getId)
-      .recover(throwable -> succeededFuture(proposedId));
   }
 }

--- a/src/main/java/org/folio/services/SmtpConfigurationService.java
+++ b/src/main/java/org/folio/services/SmtpConfigurationService.java
@@ -39,9 +39,10 @@ public class SmtpConfigurationService {
         : succeededFuture(configs.get(0)));
   }
 
-  public Future<String> createSmtpConfiguration(SmtpConfiguration smtpConfiguration) {
+  public Future<SmtpConfiguration> createSmtpConfiguration(SmtpConfiguration smtpConfiguration) {
     return getSmtpConfigurationId()
-      .compose(id -> repository.save(smtpConfiguration, id));
+      .compose(id -> repository.save(smtpConfiguration, id))
+      .map(smtpConfiguration::withId);
   }
 
   public Future<SmtpConfiguration> updateSmtpConfiguration(SmtpConfiguration smtpConfiguration) {

--- a/src/main/java/org/folio/services/email/impl/MailServiceImpl.java
+++ b/src/main/java/org/folio/services/email/impl/MailServiceImpl.java
@@ -5,17 +5,7 @@ import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.isNoneBlank;
-import static org.folio.enums.SmtpEmail.AUTH_METHODS;
-import static org.folio.enums.SmtpEmail.EMAIL_PASSWORD;
-import static org.folio.enums.SmtpEmail.EMAIL_SMTP_HOST;
-import static org.folio.enums.SmtpEmail.EMAIL_SMTP_LOGIN_OPTION;
-import static org.folio.enums.SmtpEmail.EMAIL_SMTP_PORT;
-import static org.folio.enums.SmtpEmail.EMAIL_SMTP_SSL;
-import static org.folio.enums.SmtpEmail.EMAIL_START_TLS_OPTIONS;
-import static org.folio.enums.SmtpEmail.EMAIL_TRUST_ALL;
-import static org.folio.enums.SmtpEmail.EMAIL_USERNAME;
 import static org.folio.rest.impl.base.AbstractEmail.RETRY_MAX_ATTEMPTS;
-import static org.folio.util.EmailUtils.getEmailConfig;
 import static org.folio.util.EmailUtils.getMessageConfig;
 
 import java.util.Base64;
@@ -30,9 +20,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.Attachment;
-import org.folio.rest.jaxrs.model.Config;
-import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.EmailEntity;
+import org.folio.rest.jaxrs.model.EmailHeader;
+import org.folio.rest.jaxrs.model.SmtpConfiguration;
 import org.folio.services.email.MailService;
 
 import io.vertx.core.AsyncResult;
@@ -54,7 +44,6 @@ public class MailServiceImpl implements MailService {
   private static final String ERROR_SENDING_EMAIL = "Error in the 'mod-email' module, the module didn't send email | message: %s";
   private static final String ERROR_ATTACHMENT_DATA = "Error attaching the `%s` file to email!";
   private static final String INCORRECT_ATTACHMENT_DATA = "No data attachment!";
-  private static final String EMAIL_HEADERS_CONFIG_NAME = "email.headers";
 
   private final Vertx vertx;
 
@@ -66,14 +55,15 @@ public class MailServiceImpl implements MailService {
   }
 
   @Override
-  public void sendEmail(JsonObject configJson, JsonObject emailJson,
+  public void sendEmail(JsonObject smtpConfigurationJson, JsonObject emailJson,
     Handler<AsyncResult<JsonObject>> resultHandler) {
 
+    SmtpConfiguration smtpConfiguration = smtpConfigurationJson.mapTo(SmtpConfiguration.class);
+
     try {
-      Configurations configurations = configJson.mapTo(Configurations.class);
       EmailEntity emailEntity = emailJson.mapTo(EmailEntity.class);
-      MailConfig mailConfig = getMailConfig(configurations);
-      MailMessage mailMessage = getMailMessage(emailEntity, configurations);
+      MailConfig mailConfig = getMailConfig(smtpConfiguration);
+      MailMessage mailMessage = getMailMessage(emailEntity, smtpConfiguration);
       String emailId = emailEntity.getId();
       long start = currentTimeMillis();
 
@@ -100,20 +90,20 @@ public class MailServiceImpl implements MailService {
     return client;
   }
 
-  private MailConfig getMailConfig(Configurations configurations) {
+  private MailConfig getMailConfig(SmtpConfiguration smtpConfiguration) {
     return new MailConfig()
-      .setAuthMethods(getEmailConfig(configurations, AUTH_METHODS, String.class))
-      .setHostname(getEmailConfig(configurations, EMAIL_SMTP_HOST, String.class))
-      .setPort(getEmailConfig(configurations, EMAIL_SMTP_PORT, Integer.class))
-      .setSsl(getEmailConfig(configurations, EMAIL_SMTP_SSL, Boolean.class))
-      .setStarttls(getEmailConfig(configurations, EMAIL_START_TLS_OPTIONS, StartTLSOptions.class))
-      .setTrustAll(getEmailConfig(configurations, EMAIL_TRUST_ALL, Boolean.class))
-      .setLogin(getEmailConfig(configurations, EMAIL_SMTP_LOGIN_OPTION, LoginOption.class))
-      .setUsername(getEmailConfig(configurations, EMAIL_USERNAME, String.class))
-      .setPassword(getEmailConfig(configurations, EMAIL_PASSWORD, String.class));
+      .setAuthMethods(smtpConfiguration.getAuthMethods())
+      .setHostname(smtpConfiguration.getHost())
+      .setPort(smtpConfiguration.getPort())
+      .setSsl(smtpConfiguration.getSsl())
+      .setStarttls(StartTLSOptions.valueOf(smtpConfiguration.getStartTlsOptions().value()))
+      .setTrustAll(smtpConfiguration.getTrustAll())
+      .setLogin(LoginOption.valueOf(smtpConfiguration.getLoginOption().value()))
+      .setUsername(smtpConfiguration.getUsername())
+      .setPassword(smtpConfiguration.getPassword());
   }
 
-  private MailMessage getMailMessage(EmailEntity emailEntity, Configurations configurations) {
+  private MailMessage getMailMessage(EmailEntity emailEntity, SmtpConfiguration smtpConfiguration) {
     MailMessage mailMessage = new MailMessage()
       .setFrom(getMessageConfig(emailEntity.getFrom()))
       .setTo(getMessageConfig(emailEntity.getTo()))
@@ -127,7 +117,7 @@ public class MailServiceImpl implements MailService {
       mailMessage.setText(getMessageConfig(emailEntity.getBody()));
     }
 
-    addHeadersFromConfiguration(mailMessage, configurations);
+    addHeadersFromConfiguration(mailMessage, smtpConfiguration);
 
     return mailMessage;
   }
@@ -163,11 +153,10 @@ public class MailServiceImpl implements MailService {
     return Buffer.buffer(decode);
   }
 
-  public static void addHeadersFromConfiguration(MailMessage message, Configurations configurations) {
-    Map<String, String> headers = configurations.getConfigs().stream()
-      .filter(config -> EMAIL_HEADERS_CONFIG_NAME.equals(config.getConfigName()))
-      .filter(config -> isNoneBlank(config.getCode(), config.getValue()))
-      .collect(toMap(Config::getCode, Config::getValue));
+  public static void addHeadersFromConfiguration(MailMessage message, SmtpConfiguration smtpConfiguration) {
+    Map<String, String> headers = smtpConfiguration.getEmailHeaders().stream()
+      .filter(header -> isNoneBlank(header.getName(), header.getValue()))
+      .collect(toMap(EmailHeader::getName, EmailHeader::getValue));
 
     if (headers.isEmpty()) {
       return;

--- a/src/main/java/org/folio/services/email/impl/MailServiceImpl.java
+++ b/src/main/java/org/folio/services/email/impl/MailServiceImpl.java
@@ -3,6 +3,7 @@ package org.folio.services.email.impl;
 import static io.vertx.core.Future.failedFuture;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
+import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.folio.rest.impl.base.AbstractEmail.RETRY_MAX_ATTEMPTS;
@@ -91,16 +92,32 @@ public class MailServiceImpl implements MailService {
   }
 
   private MailConfig getMailConfig(SmtpConfiguration smtpConfiguration) {
+    boolean ssl = ofNullable(smtpConfiguration.getSsl()).orElse(false);
+
+    StartTLSOptions startTLSOptions = StartTLSOptions.valueOf(
+      ofNullable(smtpConfiguration.getStartTlsOptions())
+        .orElse(SmtpConfiguration.StartTlsOptions.OPTIONAL)
+        .value());
+
+    boolean trustAll = ofNullable(smtpConfiguration.getTrustAll()).orElse(false);
+
+    LoginOption loginOption = LoginOption.valueOf(
+      ofNullable(smtpConfiguration.getLoginOption())
+        .orElse(SmtpConfiguration.LoginOption.NONE)
+        .value());
+
+    String authMethods = ofNullable(smtpConfiguration.getAuthMethods()).orElse(StringUtils.EMPTY);
+
     return new MailConfig()
-      .setAuthMethods(smtpConfiguration.getAuthMethods())
       .setHostname(smtpConfiguration.getHost())
       .setPort(smtpConfiguration.getPort())
-      .setSsl(smtpConfiguration.getSsl())
-      .setStarttls(StartTLSOptions.valueOf(smtpConfiguration.getStartTlsOptions().value()))
-      .setTrustAll(smtpConfiguration.getTrustAll())
-      .setLogin(LoginOption.valueOf(smtpConfiguration.getLoginOption().value()))
       .setUsername(smtpConfiguration.getUsername())
-      .setPassword(smtpConfiguration.getPassword());
+      .setPassword(smtpConfiguration.getPassword())
+      .setSsl(ssl)
+      .setTrustAll(trustAll)
+      .setLogin(loginOption)
+      .setStarttls(startTLSOptions)
+      .setAuthMethods(authMethods);
   }
 
   private MailMessage getMailMessage(EmailEntity emailEntity, SmtpConfiguration smtpConfiguration) {

--- a/src/main/java/org/folio/util/EmailUtils.java
+++ b/src/main/java/org/folio/util/EmailUtils.java
@@ -2,7 +2,6 @@ package org.folio.util;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
-import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isNoneBlank;

--- a/src/main/java/org/folio/util/EmailUtils.java
+++ b/src/main/java/org/folio/util/EmailUtils.java
@@ -141,10 +141,10 @@ public class EmailUtils {
       .withPassword(getEmailConfig(configurations, EMAIL_PASSWORD, String.class))
       .withSsl(getEmailConfig(configurations, EMAIL_SMTP_SSL, Boolean.class))
       .withTrustAll(getEmailConfig(configurations, EMAIL_TRUST_ALL, Boolean.class))
-      .withLoginOption(getEmailConfig(configurations, EMAIL_SMTP_LOGIN_OPTION,
-        SmtpConfiguration.LoginOption.class))
-      .withStartTlsOptions(getEmailConfig(configurations, EMAIL_START_TLS_OPTIONS,
-        SmtpConfiguration.StartTlsOptions.class))
+      .withLoginOption(SmtpConfiguration.LoginOption.valueOf(
+        getEmailConfig(configurations, EMAIL_SMTP_LOGIN_OPTION, LoginOption.class).toString()))
+      .withStartTlsOptions(SmtpConfiguration.StartTlsOptions.valueOf(
+        getEmailConfig(configurations, EMAIL_START_TLS_OPTIONS, StartTLSOptions.class).toString()))
       .withAuthMethods(getEmailConfig(configurations, AUTH_METHODS, String.class))
       .withFrom(getEmailConfig(configurations, EMAIL_FROM, String.class))
       .withEmailHeaders(configurations.getConfigs().stream()

--- a/src/main/resources/templates/db_scripts/addOneRowConstraintToSmtpConfiguration.sql
+++ b/src/main/resources/templates/db_scripts/addOneRowConstraintToSmtpConfiguration.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX one_row_only_uidx ON smtp_configuration (( true ));

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -19,6 +19,11 @@
           "removeAccents": false
         }
       ]
+    },
+    {
+      "tableName": "smtp_configuration",
+      "fromModuleVersion": "1.14.1",
+      "withMetadata": true
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,5 +1,11 @@
 {
-  "scripts": [],
+  "scripts": [
+    {
+      "run": "after",
+      "snippetPath": "addOneRowConstraintToSmtpConfiguration.sql",
+      "fromModuleVersion": "1.14.1"
+    }
+  ],
   "tables": [
     {
       "tableName": "email_statistics",

--- a/src/test/java/org/folio/matchers/JsonMatchers.java
+++ b/src/test/java/org/folio/matchers/JsonMatchers.java
@@ -1,0 +1,65 @@
+package org.folio.matchers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import io.vertx.core.json.JsonObject;
+
+public class JsonMatchers {
+
+  public static Matcher<String> matchesJson(JsonObject expectedProperties) {
+    return matchesJson(expectedProperties, List.of());
+  }
+
+  public static Matcher<String> matchesJson(JsonObject expectedProperties,
+    List<String> ignoredProperties) {
+
+    return new TypeSafeMatcher<>() {
+      @Override
+      public boolean matchesSafely(String actualString) {
+        JsonObject actual = new JsonObject(actualString);
+
+        List<String> actualFieldNames = new ArrayList<>(actual.fieldNames());
+        actualFieldNames.removeAll(ignoredProperties);
+
+        List<String> expectedFieldNames = new ArrayList<>(expectedProperties.fieldNames());
+        expectedFieldNames.removeAll(ignoredProperties);
+
+        if (!actualFieldNames.containsAll(expectedFieldNames) ||
+          !expectedFieldNames.containsAll(actualFieldNames)) {
+
+          return false;
+        }
+
+        for (Map.Entry<String, Object> expectedProperty : expectedProperties) {
+          final String propertyKey = expectedProperty.getKey();
+          final Object expectedValue = expectedProperty.getValue();
+          final Object actualValue = actual.getValue(propertyKey);
+
+          if (ignoredProperties.contains(propertyKey)) {
+            continue;
+          }
+
+          if (!Objects.equals(expectedValue, actualValue)) {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Json object has following properties")
+          .appendValue(expectedProperties.toString());
+
+      }
+    };
+  }
+}

--- a/src/test/java/org/folio/rest/impl/EmailAPITest.java
+++ b/src/test/java/org/folio/rest/impl/EmailAPITest.java
@@ -51,7 +51,7 @@ public class EmailAPITest extends AbstractAPITest {
     initFailModConfigStub(mockServerPort);
 
     String okapiEmailEntity = getEmailEntity("user@user.com", "admin@admin.com", null);
-    String expectedErrMsg = "Error looking up config at url";
+    String expectedErrMsg = "Error looking up config at";
 
     post(REST_PATH_EMAIL, okapiEmailEntity)
       .then()

--- a/src/test/java/org/folio/rest/impl/MailConfigTest.java
+++ b/src/test/java/org/folio/rest/impl/MailConfigTest.java
@@ -1,7 +1,9 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.json.JsonObject.mapFrom;
+import static org.folio.util.StubUtils.createConfigurations;
 import static org.folio.util.StubUtils.createSmtpConfiguration;
+import static org.folio.util.StubUtils.initModConfigStub;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
@@ -9,6 +11,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.EmailEntity;
 import org.folio.rest.jaxrs.model.SmtpConfiguration;
 import org.folio.services.email.impl.MailServiceImpl;
@@ -45,6 +48,10 @@ public class MailConfigTest {
 
   @Test
   public void messageShouldIncludeAuthMethodsFromConfiguration() throws Exception {
+    Configurations configurations = createConfigurations("user", "pws", "localhost",
+      "2500", AUTH_METHODS);
+    initModConfigStub(mockServer.port(), configurations);
+
     SmtpConfiguration smtpConfiguration = createSmtpConfiguration("user", "pws", "localhost", 2500,
       AUTH_METHODS);
 

--- a/src/test/java/org/folio/rest/impl/MailConfigTest.java
+++ b/src/test/java/org/folio/rest/impl/MailConfigTest.java
@@ -1,7 +1,7 @@
 package org.folio.rest.impl;
 
-import static org.folio.util.StubUtils.createConfigurations;
-import static org.folio.util.StubUtils.initModConfigStub;
+import static io.vertx.core.json.JsonObject.mapFrom;
+import static org.folio.util.StubUtils.createSmtpConfiguration;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
@@ -9,8 +9,8 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.EmailEntity;
+import org.folio.rest.jaxrs.model.SmtpConfiguration;
 import org.folio.services.email.impl.MailServiceImpl;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,9 +45,8 @@ public class MailConfigTest {
 
   @Test
   public void messageShouldIncludeAuthMethodsFromConfiguration() throws Exception {
-    Configurations configurations = createConfigurations("user", "pws", "localhost",
-      "2500", AUTH_METHODS);
-    initModConfigStub(mockServer.port(), configurations);
+    SmtpConfiguration smtpConfiguration = createSmtpConfiguration("user", "pws", "localhost", 2500,
+      AUTH_METHODS);
 
     String sender = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
     String recipient = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
@@ -64,8 +63,8 @@ public class MailConfigTest {
     MailConfig mailConfigMock = PowerMockito.mock(MailConfig.class);
     whenNew(MailConfig.class).withNoArguments().thenReturn(mailConfigMock);
 
-    new MailServiceImpl(Vertx.vertx()).sendEmail(JsonObject.mapFrom(configurations),
-      JsonObject.mapFrom(emailEntity), asyncResult -> {});
+    new MailServiceImpl(Vertx.vertx()).sendEmail(mapFrom(smtpConfiguration),
+      mapFrom(emailEntity), asyncResult -> {});
 
     verifyNew(MailConfig.class, Mockito.times(1))
       .withNoArguments();

--- a/src/test/java/org/folio/rest/impl/MailConfigTest.java
+++ b/src/test/java/org/folio/rest/impl/MailConfigTest.java
@@ -66,8 +66,8 @@ public class MailConfigTest {
       .withBody(msg)
       .withOutputFormat(MediaType.TEXT_PLAIN);
 
-    MailConfig mailConfigMock = PowerMockito.mock(MailConfig.class);
-    whenNew(MailConfig.class).withNoArguments().thenReturn(mailConfigMock);
+    MailConfig mailConfigSpy = PowerMockito.spy(new MailConfig());
+    whenNew(MailConfig.class).withNoArguments().thenReturn(mailConfigSpy);
 
     new MailServiceImpl(Vertx.vertx()).sendEmail(mapFrom(smtpConfiguration),
       mapFrom(emailEntity), asyncResult -> {});
@@ -75,7 +75,7 @@ public class MailConfigTest {
     verifyNew(MailConfig.class, Mockito.times(1))
       .withNoArguments();
 
-    verify(mailConfigMock, Mockito.times(1))
+    verify(mailConfigSpy, Mockito.times(1))
         .setAuthMethods(AUTH_METHODS);
   }
 }

--- a/src/test/java/org/folio/rest/impl/MailConfigTest.java
+++ b/src/test/java/org/folio/rest/impl/MailConfigTest.java
@@ -1,6 +1,7 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.json.JsonObject.mapFrom;
+import static org.folio.util.StubUtils.buildSmtpConfiguration;
 import static org.folio.util.StubUtils.createConfigurations;
 import static org.folio.util.StubUtils.initModConfigStub;
 import static org.mockito.Mockito.verify;
@@ -12,6 +13,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.EmailEntity;
+import org.folio.rest.jaxrs.model.SmtpConfiguration;
 import org.folio.services.email.impl.MailServiceImpl;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,6 +51,9 @@ public class MailConfigTest {
       "2500", AUTH_METHODS);
     initModConfigStub(mockServer.port(), configurations);
 
+    SmtpConfiguration smtpConfiguration = buildSmtpConfiguration("user", "pws", "localhost",
+      2500, AUTH_METHODS);
+
     String sender = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
     String recipient = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
     String msg = "Test text for the message. Random text: " + RandomStringUtils.randomAlphabetic(20);
@@ -64,7 +69,7 @@ public class MailConfigTest {
     MailConfig mailConfigMock = PowerMockito.mock(MailConfig.class);
     whenNew(MailConfig.class).withNoArguments().thenReturn(mailConfigMock);
 
-    new MailServiceImpl(Vertx.vertx()).sendEmail(mapFrom(configurations),
+    new MailServiceImpl(Vertx.vertx()).sendEmail(mapFrom(smtpConfiguration),
       mapFrom(emailEntity), asyncResult -> {});
 
     verifyNew(MailConfig.class, Mockito.times(1))

--- a/src/test/java/org/folio/rest/impl/MailConfigTest.java
+++ b/src/test/java/org/folio/rest/impl/MailConfigTest.java
@@ -2,7 +2,6 @@ package org.folio.rest.impl;
 
 import static io.vertx.core.json.JsonObject.mapFrom;
 import static org.folio.util.StubUtils.createConfigurations;
-import static org.folio.util.StubUtils.createSmtpConfiguration;
 import static org.folio.util.StubUtils.initModConfigStub;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
@@ -13,7 +12,6 @@ import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.rest.jaxrs.model.EmailEntity;
-import org.folio.rest.jaxrs.model.SmtpConfiguration;
 import org.folio.services.email.impl.MailServiceImpl;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,7 +27,6 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mail.MailConfig;
 
 @RunWith(PowerMockRunner.class)
@@ -52,9 +49,6 @@ public class MailConfigTest {
       "2500", AUTH_METHODS);
     initModConfigStub(mockServer.port(), configurations);
 
-    SmtpConfiguration smtpConfiguration = createSmtpConfiguration("user", "pws", "localhost", 2500,
-      AUTH_METHODS);
-
     String sender = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
     String recipient = String.format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
     String msg = "Test text for the message. Random text: " + RandomStringUtils.randomAlphabetic(20);
@@ -70,7 +64,7 @@ public class MailConfigTest {
     MailConfig mailConfigMock = PowerMockito.mock(MailConfig.class);
     whenNew(MailConfig.class).withNoArguments().thenReturn(mailConfigMock);
 
-    new MailServiceImpl(Vertx.vertx()).sendEmail(mapFrom(smtpConfiguration),
+    new MailServiceImpl(Vertx.vertx()).sendEmail(mapFrom(configurations),
       mapFrom(emailEntity), asyncResult -> {});
 
     verifyNew(MailConfig.class, Mockito.times(1))

--- a/src/test/java/org/folio/rest/impl/RetryFailedEmailsTest.java
+++ b/src/test/java/org/folio/rest/impl/RetryFailedEmailsTest.java
@@ -121,6 +121,7 @@ public class RetryFailedEmailsTest extends AbstractAPITest {
 
     verifyStoredEmails(1, FAILURE, 1, true, expectedErrorMessage);
     initModConfigStub(userMockServer.port(), getWiserMockConfigurations());
+    deleteLocalConfigurationAndWait();
     runRetryJobAndWaitForResult(1, DELIVERED, 2, false, MESSAGE_WAS_DELIVERED);
   }
 

--- a/src/test/java/org/folio/rest/impl/SendingEmailTest.java
+++ b/src/test/java/org/folio/rest/impl/SendingEmailTest.java
@@ -15,6 +15,7 @@ import static org.folio.util.StubUtils.getWiserMockConfigurations;
 import static org.folio.util.StubUtils.initFailModConfigStub;
 import static org.folio.util.StubUtils.initModConfigStub;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
@@ -35,6 +36,7 @@ import org.junit.Test;
 import org.subethamail.wiser.WiserMessage;
 
 import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
 import junit.framework.AssertionFailedError;
 
 public class SendingEmailTest extends AbstractAPITest {
@@ -512,10 +514,16 @@ public class SendingEmailTest extends AbstractAPITest {
   }
 
   private void checkThatCorrectConfigCopiedToLocalDb() {
-    get(REST_PATH_SMTP_CONFIGURATION)
+    Response response = get(REST_PATH_SMTP_CONFIGURATION)
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body(matchesJson(buildWiserSmtpConfiguration(), List.of("id", "ssl", "trustAll",
-        "loginOption", "startTlsOptions", "authMethods", "from", "emailHeaders")));
+      .extract()
+      .response();
+
+    String configuration = new JsonObject(response.body().asString())
+      .getJsonArray("smtpConfigurations")
+      .getJsonObject(0)
+      .encodePrettily();
+    assertThat(configuration, matchesJson(buildWiserSmtpConfiguration(), List.of("id")));
   }
 }

--- a/src/test/java/org/folio/rest/impl/SendingEmailTest.java
+++ b/src/test/java/org/folio/rest/impl/SendingEmailTest.java
@@ -218,6 +218,9 @@ public class SendingEmailTest extends AbstractAPITest {
     // init correct SMTP mock configuration
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
 
+    // delete incorrect configuration from local DB
+    deleteLocalConfigurationAndWait();
+
     response = sendEmail(emailEntity)
       .then()
       .statusCode(HttpStatus.SC_OK)

--- a/src/test/java/org/folio/rest/impl/SendingEmailTest.java
+++ b/src/test/java/org/folio/rest/impl/SendingEmailTest.java
@@ -32,6 +32,7 @@ import org.apache.http.HttpStatus;
 import org.folio.rest.impl.base.AbstractAPITest;
 import org.folio.rest.jaxrs.model.Attachment;
 import org.folio.rest.jaxrs.model.EmailEntity;
+import org.junit.Before;
 import org.junit.Test;
 import org.subethamail.wiser.WiserMessage;
 
@@ -40,10 +41,15 @@ import io.vertx.core.json.JsonObject;
 import junit.framework.AssertionFailedError;
 
 public class SendingEmailTest extends AbstractAPITest {
-
+  
+  private int mockServerPort;
+  @Before
+  public void setUp() {
+    mockServerPort = userMockServer.port();
+  }
+  
   @Test
   public void sendTextEmail() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
     String sender = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
     String recipient = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
@@ -74,7 +80,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void sendHtmlEmail() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
     String sender = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
     String recipient = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
@@ -104,7 +109,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void sendHtmlEmailAttachments() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
     String sender = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
     String recipient = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
@@ -150,7 +154,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void sendHtmlEmailAttachmentsWithoutData() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
     String sender = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
     String recipient = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
@@ -188,8 +191,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void checkSendingEmailWithDifferentConfigs() throws Exception {
-    int mockServerPort = userMockServer.port();
-
     // init incorrect SMTP mock configuration
     initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
     String sender = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
@@ -254,7 +255,6 @@ public class SendingEmailTest extends AbstractAPITest {
       "X-CUSTOM-HEADER", "customHeaderValue"
     );
 
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, createConfigurationsWithCustomHeaders(customHeaders));
     String sender = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(7));
     String recipient = format(ADDRESS_TEMPLATE, RandomStringUtils.randomAlphabetic(5));
@@ -299,7 +299,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldSucceedWhenBothLocalAndRemoteConfigsExistAndAreValid() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
     createWiserSmtpConfigurationInDb();
 
@@ -315,7 +314,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldSucceedWhenBothLocalAndRemoteConfigsExistAndRemoteIsInvalid() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getIncorrectConfigurations());
     createWiserSmtpConfigurationInDb();
 
@@ -324,7 +322,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldSucceedWhenBothLocalAndRemoteConfigsExistAndRemoteIsIncorrectForWiser() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
     createWiserSmtpConfigurationInDb();
 
@@ -333,7 +330,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldSucceedWhenOnlyRemoteConfigExistsAndIsValid() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
 
     sendEmailAndAssertDelivered();
@@ -342,7 +338,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenNoneOfTheConfigsExist() {
-    int mockServerPort = userMockServer.port();
     initFailModConfigStub(mockServerPort);
 
     sendEmailAndAssertFailure(HttpStatus.SC_BAD_REQUEST);
@@ -350,7 +345,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenOnlyRemoteConfigExistsAndIsInvalid() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getIncorrectConfigurations());
 
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
@@ -358,7 +352,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenOnlyRemoteConfigExistsAndIsIncorrectForWiser() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
 
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
@@ -366,7 +359,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldSucceedWhenBothConfigsExistAndLocalIsInvalid() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
 
     createInvalidSmtpConfigurationInDb();
@@ -377,7 +369,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenOnlyLocalConfigExistsAndIsInvalid() {
-    int mockServerPort = userMockServer.port();
     initFailModConfigStub(mockServerPort);
 
     createInvalidSmtpConfigurationInDb();
@@ -387,7 +378,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenBothConfigsExistAndBothAreInvalid() {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getIncorrectConfigurations());
 
     createInvalidSmtpConfigurationInDb();
@@ -397,7 +387,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenBothConfigsExistAndLocalIsInvalidAndRemoteIsIncorrectForWiser() {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
 
     createInvalidSmtpConfigurationInDb();
@@ -407,7 +396,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenBothConfigsExistAndLocalIsIncorrectForWiser() throws Exception {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
 
     createIncorrectWiserSmtpConfigurationInDb();
@@ -417,7 +405,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenOnlyLocalConfigExistsAndIsIncorrectForWiser() {
-    int mockServerPort = userMockServer.port();
     initFailModConfigStub(mockServerPort);
 
     createIncorrectWiserSmtpConfigurationInDb();
@@ -427,7 +414,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenBothConfigsExistAndLocalIsIncorrectForWiserAndRemoteIsInvalid() {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getIncorrectConfigurations());
 
     createIncorrectWiserSmtpConfigurationInDb();
@@ -437,7 +423,6 @@ public class SendingEmailTest extends AbstractAPITest {
 
   @Test
   public void shouldFailWhenBothConfigsExistAndBothAreIncorrectForWiser() {
-    int mockServerPort = userMockServer.port();
     initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
 
     createIncorrectWiserSmtpConfigurationInDb();

--- a/src/test/java/org/folio/rest/impl/SendingEmailTest.java
+++ b/src/test/java/org/folio/rest/impl/SendingEmailTest.java
@@ -301,14 +301,12 @@ public class SendingEmailTest extends AbstractAPITest {
   public void shouldSucceedWhenBothLocalAndRemoteConfigsExistAndAreValid() throws Exception {
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
     createWiserSmtpConfigurationInDb();
-
     sendEmailAndAssertDelivered();
   }
 
   @Test
   public void shouldSucceedWhenOnlyLocalConfigExistsAndIsValid() throws Exception {
     createWiserSmtpConfigurationInDb();
-
     sendEmailAndAssertDelivered();
   }
 
@@ -316,7 +314,6 @@ public class SendingEmailTest extends AbstractAPITest {
   public void shouldSucceedWhenBothLocalAndRemoteConfigsExistAndRemoteIsInvalid() throws Exception {
     initModConfigStub(mockServerPort, getIncorrectConfigurations());
     createWiserSmtpConfigurationInDb();
-
     sendEmailAndAssertDelivered();
   }
 
@@ -324,14 +321,12 @@ public class SendingEmailTest extends AbstractAPITest {
   public void shouldSucceedWhenBothLocalAndRemoteConfigsExistAndRemoteIsIncorrectForWiser() throws Exception {
     initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
     createWiserSmtpConfigurationInDb();
-
     sendEmailAndAssertDelivered();
   }
 
   @Test
   public void shouldSucceedWhenOnlyRemoteConfigExistsAndIsValid() throws Exception {
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
-
     sendEmailAndAssertDelivered();
     checkThatCorrectConfigCopiedToLocalDb();
   }
@@ -339,30 +334,25 @@ public class SendingEmailTest extends AbstractAPITest {
   @Test
   public void shouldFailWhenNoneOfTheConfigsExist() {
     initFailModConfigStub(mockServerPort);
-
     sendEmailAndAssertFailure(HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test
   public void shouldFailWhenOnlyRemoteConfigExistsAndIsInvalid() throws Exception {
     initModConfigStub(mockServerPort, getIncorrectConfigurations());
-
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
   }
 
   @Test
   public void shouldFailWhenOnlyRemoteConfigExistsAndIsIncorrectForWiser() throws Exception {
     initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
-
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
   }
 
   @Test
   public void shouldSucceedWhenBothConfigsExistAndLocalIsInvalid() throws Exception {
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
-
     createInvalidSmtpConfigurationInDb();
-
     sendEmailAndAssertDelivered();
     checkThatCorrectConfigCopiedToLocalDb();
   }
@@ -370,63 +360,49 @@ public class SendingEmailTest extends AbstractAPITest {
   @Test
   public void shouldFailWhenOnlyLocalConfigExistsAndIsInvalid() {
     initFailModConfigStub(mockServerPort);
-
     createInvalidSmtpConfigurationInDb();
-
     sendEmailAndAssertFailure(HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test
   public void shouldFailWhenBothConfigsExistAndBothAreInvalid() {
     initModConfigStub(mockServerPort, getIncorrectConfigurations());
-
     createInvalidSmtpConfigurationInDb();
-
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
   }
 
   @Test
   public void shouldFailWhenBothConfigsExistAndLocalIsInvalidAndRemoteIsIncorrectForWiser() {
     initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
-
     createInvalidSmtpConfigurationInDb();
-
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
   }
 
   @Test
   public void shouldFailWhenBothConfigsExistAndLocalIsIncorrectForWiser() throws Exception {
     initModConfigStub(mockServerPort, getWiserMockConfigurations());
-
     createIncorrectWiserSmtpConfigurationInDb();
-
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
   }
 
   @Test
   public void shouldFailWhenOnlyLocalConfigExistsAndIsIncorrectForWiser() {
     initFailModConfigStub(mockServerPort);
-
     createIncorrectWiserSmtpConfigurationInDb();
-
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
   }
 
   @Test
   public void shouldFailWhenBothConfigsExistAndLocalIsIncorrectForWiserAndRemoteIsInvalid() {
     initModConfigStub(mockServerPort, getIncorrectConfigurations());
-
     createIncorrectWiserSmtpConfigurationInDb();
-
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
   }
 
   @Test
   public void shouldFailWhenBothConfigsExistAndBothAreIncorrectForWiser() {
     initModConfigStub(mockServerPort, getIncorrectWiserMockConfigurations());
-
     createIncorrectWiserSmtpConfigurationInDb();
-
     sendEmailAndAssertFailure(HttpStatus.SC_OK);
   }
 

--- a/src/test/java/org/folio/rest/impl/SmtpConfigurationTest.java
+++ b/src/test/java/org/folio/rest/impl/SmtpConfigurationTest.java
@@ -10,6 +10,7 @@ import org.apache.http.HttpStatus;
 import org.folio.rest.impl.base.AbstractAPITest;
 import org.junit.Test;
 
+import io.restassured.response.Response;
 import io.vertx.core.json.JsonObject;
 
 public class SmtpConfigurationTest extends AbstractAPITest {
@@ -34,21 +35,44 @@ public class SmtpConfigurationTest extends AbstractAPITest {
       .statusCode(HttpStatus.SC_CREATED)
       .body(matchesJson(smtpConfiguration, List.of("id", "metadata")));
 
-    get(REST_PATH_SMTP_CONFIGURATION)
+    Response getResponse = get(REST_PATH_SMTP_CONFIGURATION)
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body(matchesJson(smtpConfiguration, List.of("id", "metadata")));
+      .body(matchesJson(smtpConfiguration, List.of("id", "metadata")))
+      .extract()
+      .response();
 
-    JsonObject updatedSmtpConfiguration = smtpConfiguration.put("username", "updated-username");
+    String id = new JsonObject(getResponse.body().asString()).getString("id");
+
+    // PUT without an ID should succeed
+    JsonObject updatedSmtpConfiguration = smtpConfiguration
+      .copy()
+      .put("username", "updated-username");
     put(REST_PATH_SMTP_CONFIGURATION, updatedSmtpConfiguration.encodePrettily())
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body(matchesJson(updatedSmtpConfiguration, List.of("id", "metadata")));
 
+    // PUT with correct ID should succeed
+    JsonObject updatedSmtpConfigurationWithId = smtpConfiguration
+      .copy()
+      .put("username", "updated-username-2")
+      .put("id", id);
+    put(REST_PATH_SMTP_CONFIGURATION, updatedSmtpConfigurationWithId.encodePrettily())
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body(matchesJson(updatedSmtpConfigurationWithId, List.of("metadata")));
+
+    // PUT with wrong ID should return 404
+    put(REST_PATH_SMTP_CONFIGURATION,
+      updatedSmtpConfiguration.put("id", UUID.randomUUID().toString()).encodePrettily())
+      .then()
+      .statusCode(HttpStatus.SC_NOT_FOUND);
+
     get(REST_PATH_SMTP_CONFIGURATION)
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body(matchesJson(updatedSmtpConfiguration, List.of("id", "metadata")));
+      .body(matchesJson(updatedSmtpConfigurationWithId, List.of("metadata")));
 
     delete(REST_PATH_SMTP_CONFIGURATION)
       .then()

--- a/src/test/java/org/folio/rest/impl/SmtpConfigurationTest.java
+++ b/src/test/java/org/folio/rest/impl/SmtpConfigurationTest.java
@@ -1,0 +1,62 @@
+package org.folio.rest.impl;
+
+import static org.folio.matchers.JsonMatchers.matchesJson;
+import static org.folio.util.StubUtils.buildSmtpConfiguration;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.http.HttpStatus;
+import org.folio.rest.impl.base.AbstractAPITest;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+
+public class SmtpConfigurationTest extends AbstractAPITest {
+
+  @Test
+  public void postSmtpConfigurationWithId() {
+    JsonObject smtpConfiguration = buildSmtpConfiguration()
+      .put("id", UUID.randomUUID().toString());
+
+    post(REST_PATH_SMTP_CONFIGURATION, smtpConfiguration.encodePrettily())
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .body(matchesJson(smtpConfiguration, List.of("metadata")));
+  }
+
+  @Test
+  public void smtpConfigurationCrud() {
+    JsonObject smtpConfiguration = buildSmtpConfiguration();
+
+    post(REST_PATH_SMTP_CONFIGURATION, smtpConfiguration.encodePrettily())
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .body(matchesJson(smtpConfiguration, List.of("id", "metadata")));
+
+    get(REST_PATH_SMTP_CONFIGURATION)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body(matchesJson(smtpConfiguration, List.of("id", "metadata")));
+
+    JsonObject updatedSmtpConfiguration = smtpConfiguration.put("username", "updated-username");
+    put(REST_PATH_SMTP_CONFIGURATION, updatedSmtpConfiguration.encodePrettily())
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body(matchesJson(updatedSmtpConfiguration, List.of("id", "metadata")));
+
+    get(REST_PATH_SMTP_CONFIGURATION)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body(matchesJson(updatedSmtpConfiguration, List.of("id", "metadata")));
+
+    delete(REST_PATH_SMTP_CONFIGURATION)
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
+
+    get(REST_PATH_SMTP_CONFIGURATION)
+      .then()
+      .statusCode(HttpStatus.SC_NOT_FOUND);
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
+++ b/src/test/java/org/folio/rest/impl/base/AbstractAPITest.java
@@ -88,6 +88,7 @@ public abstract class AbstractAPITest {
   private static final String OKAPI_URL_TEMPLATE = "http://localhost:%s";
 
   protected static final String REST_PATH_EMAIL = "/email";
+  protected static final String REST_PATH_SMTP_CONFIGURATION = "/smtp-configuration";
   private static final String PATH_WITH_QUERY_TEMPLATE = "%s?query=%s&limit=%s";
   protected static final String ADDRESS_TEMPLATE = "%s@localhost";
   private static final String SUCCESS_SEND_EMAIL = "The message has been delivered to %s";
@@ -188,17 +189,15 @@ public abstract class AbstractAPITest {
           logger.error(event.cause());
           context.fail(event.cause());
         } else {
-          async.complete();
-        }
-      });
-
-    deleteLocalConfiguration()
-      .onComplete(event -> {
-        if (event.failed()) {
-          logger.error(event.cause());
-          context.fail(event.cause());
-        } else {
-          async.complete();
+          deleteLocalConfiguration()
+            .onComplete(eventConfig -> {
+              if (eventConfig.failed()) {
+                logger.error(eventConfig.cause());
+                context.fail(eventConfig.cause());
+              } else {
+                async.complete();
+              }
+            });
         }
       });
   }
@@ -226,6 +225,11 @@ public abstract class AbstractAPITest {
       .get(String.format(PATH_WITH_QUERY_TEMPLATE, REST_PATH_EMAIL, query, DEFAULT_LIMIT));
   }
 
+  protected Response get(String path) {
+    return getRequestSpecification()
+      .get(path);
+  }
+
   protected Response post(String path) {
     return getRequestSpecification()
       .post(path);
@@ -235,6 +239,17 @@ public abstract class AbstractAPITest {
     return getRequestSpecification()
       .body(body)
       .post(path);
+  }
+
+  protected Response put(String path, String body) {
+    return getRequestSpecification()
+      .body(body)
+      .put(path);
+  }
+
+  protected Response delete(String path) {
+    return getRequestSpecification()
+      .delete(path);
   }
 
   /**

--- a/src/test/java/org/folio/util/StubUtils.java
+++ b/src/test/java/org/folio/util/StubUtils.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.enums.SmtpEmail;
 import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.Configurations;
+import org.folio.rest.jaxrs.model.SmtpConfiguration;
 
 import java.util.List;
 import java.util.Map;
@@ -104,6 +105,17 @@ public class StubUtils {
       createSmtpConfig(EMAIL_SMTP_PORT, port),
       createSmtpConfig(AUTH_METHODS, authMethods)
     )).withTotalRecords(7);
+  }
+
+  public static SmtpConfiguration createSmtpConfiguration(String user, String password,
+    String host, int port, String authMethods) {
+
+    return new SmtpConfiguration()
+      .withUsername(user)
+      .withPassword(password)
+      .withHost(host)
+      .withPort(port)
+      .withAuthMethods(authMethods);
   }
 
   private static Config createSmtpConfig(SmtpEmail code, String value) {

--- a/src/test/java/org/folio/util/StubUtils.java
+++ b/src/test/java/org/folio/util/StubUtils.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.util.stream.Collectors.toList;
+import static org.folio.HttpStatus.HTTP_NO_CONTENT;
 import static org.folio.enums.SmtpEmail.AUTH_METHODS;
 import static org.folio.enums.SmtpEmail.EMAIL_PASSWORD;
 import static org.folio.enums.SmtpEmail.EMAIL_SMTP_HOST;
@@ -26,6 +27,7 @@ public class StubUtils {
 
   private static final String MODULE_SMTP_SERVER = "SMTP_SERVER";
   private static final String URL_CONFIGURATIONS_TO_SMTP_SERVER = "/configurations/entries?query=module==" + MODULE_SMTP_SERVER;
+  private static final String URL_SINGLE_CONFIGURATION = "/configurations/entries/.+";
   private static final String CONFIG_NAME_SMTP = "smtp";
   private static final String CONFIG_NAME_EMAIL_HEADERS = "email.headers";
 
@@ -54,6 +56,12 @@ public class StubUtils {
         .withHeader("x-okapi-token", "x-okapi-token-TEST")
         .withHeader("x-okapi-url", "http://localhost:" + port)
         .withBody(JsonObject.mapFrom(configurations).toString())));
+
+    stubFor(delete(urlMatching(URL_SINGLE_CONFIGURATION))
+      .willReturn(aResponse()
+        .withStatus(HTTP_NO_CONTENT.toInt())
+        .withHeader("x-okapi-token", "x-okapi-token-TEST")
+        .withHeader("x-okapi-url", "http://localhost:" + port)));
   }
 
   public static void initFailModConfigStub(int port) {

--- a/src/test/java/org/folio/util/StubUtils.java
+++ b/src/test/java/org/folio/util/StubUtils.java
@@ -153,4 +153,21 @@ public class StubUtils {
     return configurations;
   }
 
+  public static JsonObject buildSmtpConfiguration() {
+    return new JsonObject()
+      .put("host", "localhost")
+      .put("port", 502)
+      .put("username", "username")
+      .put("password", "password")
+      .put("ssl", true)
+      .put("trustAll", false)
+      .put("loginOption", "REQUIRED")
+      .put("startTlsOptions", "DISABLED")
+      .put("authMethods", "CRAM-MD5 LOGIN PLAIN")
+      .put("from", "noreply@folio.org")
+      .put("emailHeaders", List.of(new JsonObject()
+        .put("name", "Reply-To")
+        .put("value", "noreply@folio.org")
+      ));
+  }
 }

--- a/src/test/java/org/folio/util/StubUtils.java
+++ b/src/test/java/org/folio/util/StubUtils.java
@@ -154,6 +154,7 @@ public class StubUtils {
   }
 
   public static JsonObject buildSmtpConfiguration() {
+
     return new JsonObject()
       .put("host", "localhost")
       .put("port", 502)
@@ -170,4 +171,27 @@ public class StubUtils {
         .put("value", "noreply@folio.org")
       ));
   }
+
+  public static JsonObject buildWiserSmtpConfiguration() {
+    return new JsonObject()
+      .put("host", "localhost")
+      .put("port", 2500)
+      .put("username", "user")
+      .put("password", "password");
+  }
+
+  public static JsonObject buildIncorrectWiserSmtpConfiguration() {
+    return new JsonObject()
+      .put("host", "localhost")
+      .put("port", 555)
+      .put("username", "user")
+      .put("password", "password");
+  }
+
+  public static JsonObject buildInvalidSmtpConfiguration() {
+    return new JsonObject()
+      .put("host", "localhost")
+      .put("password", "password");
+  }
+
 }

--- a/src/test/java/org/folio/util/StubUtils.java
+++ b/src/test/java/org/folio/util/StubUtils.java
@@ -166,7 +166,14 @@ public class StubUtils {
       .put("host", "localhost")
       .put("port", 2500)
       .put("username", "user")
-      .put("password", "password");
+      .put("password", "password")
+      .put("ssl", false)
+      .put("trustAll", false)
+      .put("loginOption", "NONE")
+      .put("startTlsOptions", "OPTIONAL")
+      .put("authMethods", "")
+      .put("from", "")
+      .put("emailHeaders", List.of());
   }
 
   public static JsonObject buildIncorrectWiserSmtpConfiguration() {

--- a/src/test/java/org/folio/util/StubUtils.java
+++ b/src/test/java/org/folio/util/StubUtils.java
@@ -115,17 +115,6 @@ public class StubUtils {
     )).withTotalRecords(7);
   }
 
-  public static SmtpConfiguration createSmtpConfiguration(String user, String password,
-    String host, int port, String authMethods) {
-
-    return new SmtpConfiguration()
-      .withUsername(user)
-      .withPassword(password)
-      .withHost(host)
-      .withPort(port)
-      .withAuthMethods(authMethods);
-  }
-
   private static Config createSmtpConfig(SmtpEmail code, String value) {
     return createConfig(CONFIG_NAME_SMTP, code.name(), value);
   }

--- a/src/test/java/org/folio/util/StubUtils.java
+++ b/src/test/java/org/folio/util/StubUtils.java
@@ -183,4 +183,15 @@ public class StubUtils {
       .put("password", "password");
   }
 
+  public static SmtpConfiguration buildSmtpConfiguration(String user, String password,
+    String host, int port, String authMethods) {
+
+    return new SmtpConfiguration()
+      .withUsername(user)
+      .withPassword(password)
+      .withHost(host)
+      .withPort(port)
+      .withAuthMethods(authMethods);
+  }
+
 }


### PR DESCRIPTION
Resolves [MODEMAIL-76](https://issues.folio.org/browse/MODEMAIL-76)

SMTP config moved to mod-email's own DB. CRUD from SMTP configs created.
When mod-email can't find SMTP config in the DB, it'll try to fetch it from mod-config.

TODO: remove entries from mod-config when fetched successfully.