### PR TITLE
MODEMAIL-76 Fix SMTP configuration GET endpoints

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -56,12 +56,12 @@
       "handlers": [
         {
           "methods": ["GET"],
-          "pathPattern": "/smtp-configurations",
+          "pathPattern": "/smtp-configuration",
           "permissionsRequired": ["email.smtp-configuration.collection.get"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/smtp-configurations/{smtpConfigurationId}",
+          "pathPattern": "/smtp-configuration/{smtpConfigurationId}",
           "permissionsRequired": ["email.smtp-configuration.item.get"]
         },
         {


### PR DESCRIPTION
Resolves [MODEMAIL-76](https://issues.folio.org/browse/MODEMAIL-76)

Fixes SMTP configuration _get_ and _get all_ endpoints