### PR TITLE
MODEMAIL-76 Fix DELETE Accept header, permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -21,7 +21,8 @@
             "email.message.post"
           ],
           "modulePermissions": [
-            "configuration.entries.collection.get"
+            "configuration.entries.collection.get",
+            "configuration.entries.item.delete"
           ]
         },
         {
@@ -120,7 +121,8 @@
           ],
           "pathPattern": "/delayedTask/retryFailedEmails",
           "modulePermissions": [
-            "configuration.entries.collection.get"
+            "configuration.entries.collection.get",
+            "configuration.entries.item.delete"
           ],
           "unit": "minute",
           "delay": "5"

--- a/src/main/java/org/folio/rest/client/OkapiClient.java
+++ b/src/main/java/org/folio/rest/client/OkapiClient.java
@@ -2,6 +2,7 @@ package org.folio.rest.client;
 
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.okapi.common.XOkapiHeaders.TOKEN;
 import static org.folio.okapi.common.XOkapiHeaders.URL;
@@ -10,10 +11,6 @@ import static org.folio.rest.client.WebClientProvider.getWebClient;
 import java.util.Map;
 
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -46,7 +43,7 @@ public class OkapiClient {
 
   public HttpRequest<Buffer> deleteAbs(String path) {
     return webClient.requestAbs(HttpMethod.DELETE, okapiUrl + path)
-      .putHeader(ACCEPT, APPLICATION_JSON)
+      .putHeader(ACCEPT, TEXT_PLAIN)
       .putHeader(URL, okapiUrl)
       .putHeader(TENANT, tenant)
       .putHeader(TOKEN, token);

--- a/src/test/java/org/folio/util/StubUtils.java
+++ b/src/test/java/org/folio/util/StubUtils.java
@@ -27,7 +27,7 @@ public class StubUtils {
 
   private static final String MODULE_SMTP_SERVER = "SMTP_SERVER";
   private static final String URL_CONFIGURATIONS_TO_SMTP_SERVER = "/configurations/entries?query=module==" + MODULE_SMTP_SERVER;
-  private static final String URL_SINGLE_CONFIGURATION = "/configurations/entries/.+";
+  public static final String URL_SINGLE_CONFIGURATION = "/configurations/entries/.+";
   private static final String CONFIG_NAME_SMTP = "smtp";
   private static final String CONFIG_NAME_EMAIL_HEADERS = "email.headers";
 


### PR DESCRIPTION
Resolves [MODEMAIL-76](https://issues.folio.org/browse/MODEMAIL-76)

### Purpose
Configuration entries are not deleted from mod-config. Logs:
```
10:23:11 [] [] [] [] INFO  LogUtil              10.36.1.17:50506 DELETE /configurations/entries/29d1f1cc-dbe2-43d2-9994-554d3b495cbb null HTTP_1_1 400 101 -1 tid=null Bad Request Accept header must be ["text/plain"] for this request, but it is "application/json", can not send */*
```

### Approach
- Added permissions for configuration deletion
- Changed **DELETE**'s **Accept** header value from **application/json** to **text/plain**