### PR TITLE
FOLIO-3678 MODEMAIL-92 Use GitHub Workflows api-lint and api-schema-lint and api-doc

### DIFF
--- a/.github/workflows/api-doc.yml
+++ b/.github/workflows/api-doc.yml
@@ -1,0 +1,91 @@
+name: api-doc
+
+# https://dev.folio.org/guides/api-doc/
+
+# API_TYPES: string: The space-separated list of types to consider.
+# One or more of 'RAML OAS'.
+# e.g. 'OAS'
+#
+# API_DIRECTORIES: string: The space-separated list of directories to search
+# for API description files.
+# e.g. 'src/main/resources/openapi'
+# NOTE: -- Also add each separate path to each of the "on: paths:" sections.
+# e.g. 'src/main/resources/openapi/**'
+#
+# API_EXCLUDES: string: The space-separated list of directories and files
+# to exclude from traversal, in addition to the default exclusions.
+# e.g. ''
+
+env:
+  API_TYPES: 'RAML'
+  API_DIRECTORIES: 'ramls'
+  API_EXCLUDES: ''
+  OUTPUT_DIR: 'folio-api-docs'
+  AWS_S3_BUCKET: 'foliodocs'
+  AWS_S3_FOLDER: 'api'
+  AWS_S3_REGION: 'us-east-1'
+  AWS_S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+  AWS_S3_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'ramls/**'
+    tags: '[vV][0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  api-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.REF }}
+          submodules: recursive
+      - name: Prepare folio-tools
+        run: |
+          git clone https://github.com/folio-org/folio-tools
+          cd folio-tools/api-doc \
+            && yarn install \
+            && pip3 install -r requirements.txt
+      - name: Obtain version if release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          version=$(echo ${GITHUB_REF#refs/tags/[vV]} | awk -F'.' '{ printf("%d.%d", $1, $2) }')
+          echo "VERSION_MAJ_MIN=${version}" >> $GITHUB_ENV
+      - name: Set some vars
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+      - name: Report some info
+        run: |
+          echo "REPO_NAME=${{ env.REPO_NAME }}"
+      - name: Do api-doc
+        run: |
+          if test -n "${{ env.VERSION_MAJ_MIN }}"; then
+            echo "Docs for release version ${{ env.VERSION_MAJ_MIN }}"
+            option_release=$(echo "--version ${{ env.VERSION_MAJ_MIN }}")
+          else
+            option_release=""
+          fi
+          python3 folio-tools/api-doc/api_doc.py \
+            --loglevel info \
+            --types ${{ env.API_TYPES }} \
+            --directories ${{ env.API_DIRECTORIES }} \
+            --excludes ${{ env.API_EXCLUDES }} \
+            --output ${{ env.OUTPUT_DIR }} $option_release
+      - name: Show generated files
+        working-directory: ${{ env.OUTPUT_DIR }}
+        run: ls -R
+      - name: Publish to AWS S3
+        uses: sai-sharan/aws-s3-sync-action@v0.1.0
+        with:
+          access_key: ${{ env.AWS_S3_ACCESS_KEY_ID }}
+          secret_access_key: ${{ env.AWS_S3_ACCESS_KEY }}
+          region: ${{ env.AWS_S3_REGION }}
+          source: ${{ env.OUTPUT_DIR }}
+          destination_bucket: ${{ env.AWS_S3_BUCKET }}
+          destination_prefix: ${{ env.AWS_S3_FOLDER }}
+          delete: false
+          quiet: false
+

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -1,0 +1,65 @@
+name: api-lint
+
+# https://dev.folio.org/guides/api-lint/
+
+# API_TYPES: string: The space-separated list of types to consider.
+# One or more of 'RAML OAS'.
+# e.g. 'OAS'
+#
+# API_DIRECTORIES: string: The space-separated list of directories to search
+# for API description files.
+# e.g. 'src/main/resources/openapi'
+# NOTE: -- Also add each separate path to each of the "on: paths:" sections.
+# e.g. 'src/main/resources/openapi/**'
+#
+# API_EXCLUDES: string: The space-separated list of directories and files
+# to exclude from traversal, in addition to the default exclusions.
+# e.g. ''
+#
+# API_WARNINGS: boolean: Whether to cause Warnings to be displayed,
+# and to fail the workflow.
+# e.g. false
+
+env:
+  API_TYPES: 'RAML'
+  API_DIRECTORIES: 'ramls'
+  API_EXCLUDES: ''
+  API_WARNINGS: false
+
+on:
+  push:
+    paths:
+      - 'ramls/**'
+  pull_request:
+    paths:
+      - 'ramls/**'
+
+jobs:
+  api-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Prepare folio-tools
+        run: |
+          git clone https://github.com/folio-org/folio-tools
+          cd folio-tools/api-lint \
+            && yarn install \
+            && pip3 install -r requirements.txt
+      - name: Configure default options
+        run: |
+          echo "OPTION_WARNINGS=''" >> $GITHUB_ENV
+      - name: Configure option warnings
+        if: ${{ env.API_WARNINGS == 'true' }}
+        run: |
+          echo "OPTION_WARNINGS=--warnings" >> $GITHUB_ENV
+      - name: Do api-lint
+        run: |
+          python3 folio-tools/api-lint/api_lint.py \
+            --loglevel info \
+            --types ${{ env.API_TYPES }} \
+            --directories ${{ env.API_DIRECTORIES }} \
+            --excludes ${{ env.API_EXCLUDES }} \
+            ${{ env.OPTION_WARNINGS }}

--- a/.github/workflows/api-schema-lint.yml
+++ b/.github/workflows/api-schema-lint.yml
@@ -1,0 +1,46 @@
+name: api-schema-lint
+
+# https://dev.folio.org/guides/describe-schema/
+
+# API_DIRECTORIES: string: The space-separated list of directories to search
+# for JSON Schema files.
+# e.g. 'src/main/resources/openapi'
+# NOTE: -- Also add each separate path to each of the "on: paths:" sections.
+# e.g. 'src/main/resources/openapi/**'
+#
+# API_EXCLUDES: string: The space-separated list of directories and files
+# to exclude from traversal, in addition to the default exclusions.
+# e.g. ''
+
+env:
+  API_DIRECTORIES: 'ramls'
+  API_EXCLUDES: ''
+
+on:
+  push:
+    paths:
+      - 'ramls/**'
+  pull_request:
+    paths:
+      - 'ramls/**'
+
+jobs:
+  api-schema-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Prepare folio-tools
+        run: |
+          git clone https://github.com/folio-org/folio-tools
+          cd folio-tools/api-schema-lint \
+            && yarn install \
+            && pip3 install -r requirements.txt
+      - name: Do api-schema-lint
+        run: |
+          python3 folio-tools/api-schema-lint/api_schema_lint.py \
+            --loglevel info \
+            --directories ${{ env.API_DIRECTORIES }} \
+            --excludes ${{ env.API_EXCLUDES }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,6 @@ buildMvn {
   doKubeDeploy = true
   buildNode = 'jenkins-agent-java11'
 
-  doApiLint = true
-  doApiDoc = true
-  apiTypes = 'RAML'
-  apiDirectories = 'ramls'
-
   doDocker = {
     buildJavaDocker {
       publishMaster = 'yes'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-email
 
-Copyright (C) 2018-2022 The Open Library Foundation
+Copyright (C) 2018-2023 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/ramls/email.raml
+++ b/ramls/email.raml
@@ -58,3 +58,4 @@ resourceTypes:
       searchable: {description: "searchable using CQL", example: "status==FAILURE"},
       pageable
     ]
+


### PR DESCRIPTION
[FOLIO-3678](https://issues.folio.org/browse/FOLIO-3678)

Use GitHub Workflows for [api-lint](https://dev.folio.org/guides/api-lint/) and [api-schema-lint](https://dev.folio.org/guides/describe-schema/) and [api-doc](https://dev.folio.org/guides/api-doc/)
(instead of Jenkins-operated CI stages).
