### PR TITLE
Configurable expiration time

### DIFF
--- a/ramls/examples/smtp-configuration.sample
+++ b/ramls/examples/smtp-configuration.sample
@@ -8,6 +8,7 @@
   "trustAll": false,
   "loginOption": "REQUIRED",
   "startTlsOptions": "DISABLED",
+  "expirationHours": 24,
   "authMethods": "CRAM-MD5 LOGIN PLAIN",
   "from": "noreply@folio.org",
   "emailHeaders": [

--- a/ramls/smtp-configuration.json
+++ b/ramls/smtp-configuration.json
@@ -51,6 +51,10 @@
         "REQUIRED"
       ]
     },
+    "expirationHours": {
+      "description": "Action expiration time",
+      "type": "integer"
+    },
     "authMethods": {
       "description": "Authentication methods",
       "type": "string"

--- a/src/main/java/org/folio/services/storage/impl/StorageServiceImpl.java
+++ b/src/main/java/org/folio/services/storage/impl/StorageServiceImpl.java
@@ -3,9 +3,8 @@ package org.folio.services.storage.impl;
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
 import static org.folio.util.EmailUtils.EMAIL_STATISTICS_TABLE_NAME;
-import static org.folio.util.LogUtil.*;
+import static org.folio.util.LogUtil.asJson;
 
-import io.vertx.core.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,6 +20,11 @@ import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.persist.interfaces.Results;
 import org.folio.services.storage.StorageService;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 
 public class StorageServiceImpl implements StorageService {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEMAIL-81

Okapi calls DELETE /delayedTask/expiredMessages every 30 minutes:

https://github.com/folio-org/mod-email/blob/v1.14.0/descriptors/ModuleDescriptor-template.json#L78-L85

https://github.com/folio-org/mod-email/blob/v1.14.0/src/main/java/org/folio/rest/impl/DelayedTasksAPI.java#L36-L48

https://github.com/folio-org/mod-email/blob/v1.14.0/src/main/java/org/folio/services/storage/impl/StorageServiceImpl.java#L87-L93

This deletes expired messages; messages are expired if they are at least 1 day old.

This expiration time is hard-coded: https://github.com/folio-org/mod-email/blob/v1.14.0/src/main/java/org/folio/services/storage/impl/StorageServiceImpl.java#L32

Add this expiration time to the configuration of mod-email so that the tenant can configure it.

When mod-email deletes expired messages it first fetches the configuration and uses the expiration time stored in the configuration. Only if missing 1 day is used as fall-back.

Note: This issue is blocked until mod-email's configuration has been moved from mod-configuration to mod-email.