### PR TITLE
MODEMAIL-114 Upgrade module to Vert.x 5.0 (Fix log4j2 properties)

### DIFF
--- a/src/main/resources/log4j2-json.properties
+++ b/src/main/resources/log4j2-json.properties
@@ -18,19 +18,19 @@ appender.console.layout.stacktraceAsString = true
 
 appender.console.layout.requestId.type = KeyValuePair
 appender.console.layout.requestId.key = requestId
-appender.console.layout.requestId.value = $${FolioLoggingContext:requestid}
+appender.console.layout.requestId.value = $${FolioLoggingContext:requestId}
 
 appender.console.layout.tenantId.type = KeyValuePair
 appender.console.layout.tenantId.key = tenantId
-appender.console.layout.tenantId.value = $${FolioLoggingContext:tenantid}
+appender.console.layout.tenantId.value = $${FolioLoggingContext:tenantId}
 
 appender.console.layout.userId.type = KeyValuePair
 appender.console.layout.userId.key = userId
-appender.console.layout.userId.value = $${FolioLoggingContext:userid}
+appender.console.layout.userId.value = $${FolioLoggingContext:userId}
 
 appender.console.layout.moduleId.type = KeyValuePair
 appender.console.layout.moduleId.key = moduleId
-appender.console.layout.moduleId.value = $${FolioLoggingContext:moduleid}
+appender.console.layout.moduleId.value = $${FolioLoggingContext:moduleId}
 
 rootLogger.level = info
 rootLogger.appenderRefs = info

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -12,7 +12,7 @@ appenders = console
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
+appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestId}] [$${FolioLoggingContext:tenantId}] [$${FolioLoggingContext:userId}] [$${FolioLoggingContext:moduleId}] %-5p %-20.20C{1} %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -12,7 +12,7 @@ appenders = console
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
+appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestId}] [$${FolioLoggingContext:tenantId}] [$${FolioLoggingContext:userId}] [$${FolioLoggingContext:moduleId}] %-5p %-20.20C{1} %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info


### PR DESCRIPTION
## Purpose
Align log context keys with the camelCase convention.

## Approach
Adjusted the log4j2 console appender pattern so the FolioLoggingContext placeholders use requestId, tenantId, userId, and moduleId.

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

## Related issue
[MODEMAIL-114](https://folio-org.atlassian.net/browse/MODEMAIL-114)
